### PR TITLE
2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Use these services in following service calls.
 
   Also make sure that:
 
-  - binary sensor is not disabled via entity, check .storage/core.config_entries for disabled entities
+  - binary sensor is not disabled via entity, check .storage/core.entity_registry for disabled entities, look for "disabled_by": "user" on platform "tapo_control". If it is, remove the whole entity or change to "disabled_by": null, and restart HASS.
   - binary sensor is enabled in tapo integration options
   - onvif port 2020 on camera is opened
 </details>

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Use these services in following service calls.
   - Make sure the camera can see you and your movement
   - Try walking in front of the camera
   - If above didn't work, restart the camera and try again
+
+  Also make sure that:
+
+  - binary sensor is not disabled via entity, check .storage/core.config_entries for disabled entities
+  - binary sensor is enabled in tapo integration options
+  - onvif port 2020 on camera is opened
 </details>
 
 ## Have a comment or a suggestion?

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -98,7 +98,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
         async def unsubscribe(event):
-            if(hass.data[DOMAIN][entry.entry_id]['events']):
+            if('events' in hass.data[DOMAIN][entry.entry_id] and hass.data[DOMAIN][entry.entry_id]['events']):
                 await hass.data[DOMAIN][entry.entry_id]['events'].async_stop()
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, unsubscribe)

--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -2,6 +2,11 @@ from typing import Optional
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import callback
 from .const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    return True
 
 async def async_setup_entry(hass, entry, async_add_entities):
     events = hass.data[DOMAIN][entry.entry_id]['events']

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -1,4 +1,3 @@
-import logging 
 import asyncio
 from homeassistant.helpers.config_validation import boolean
 from homeassistant.core import HomeAssistant
@@ -16,8 +15,6 @@ from homeassistant.helpers.aiohttp_client import (
 from haffmpeg.camera import CameraMjpeg
 from haffmpeg.tools import IMAGE_JPEG, ImageFrame
 from .const import *
-
-_LOGGER = logging.getLogger(__name__)
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
@@ -216,7 +213,7 @@ class TapoCamEntity(Camera):
                 if(foundKey):
                     await self.hass.async_add_executor_job(self._controller.setPreset, foundKey)
                 else:
-                    _LOGGER.error("Preset "+preset+" does not exist.")
+                    LOGGER.error("Preset "+preset+" does not exist.")
         elif tilt:
             if distance:
                 distance = float(distance)
@@ -244,7 +241,7 @@ class TapoCamEntity(Camera):
             else:
                 await self.hass.async_add_executor_job(self._controller.moveMotor, -degrees,0)
         else:
-            _LOGGER.error("Incorrect additional PTZ properties. You need to specify at least one of " + TILT + ", " + PAN + ", " + PRESET + ".")
+            LOGGER.error("Incorrect additional PTZ properties. You need to specify at least one of " + TILT + ", " + PAN + ", " + PRESET + ".")
         await self._coordinator.async_request_refresh()
 
     async def set_privacy_mode(self, privacy_mode: str):
@@ -308,7 +305,7 @@ class TapoCamEntity(Camera):
             await self.hass.async_add_executor_job(self._controller.savePreset, name)
             await self._coordinator.async_request_refresh()
         else:
-            _LOGGER.error("Incorrect "+NAME+" value. It cannot be empty or a number.")
+            LOGGER.error("Incorrect "+NAME+" value. It cannot be empty or a number.")
 
     async def delete_preset(self, preset):
         if(preset.isnumeric()):
@@ -323,7 +320,7 @@ class TapoCamEntity(Camera):
                 await self.hass.async_add_executor_job(self._controller.deletePreset, foundKey)
                 await self._coordinator.async_request_refresh()
             else:
-                _LOGGER.error("Preset "+preset+" does not exist.")
+                LOGGER.error("Preset "+preset+" does not exist.")
 
     async def format(self):
         await self.hass.async_add_executor_job(self._controller.format)

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -1,4 +1,3 @@
-from pytapo import Tapo
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_IP_ADDRESS,
@@ -13,19 +12,27 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-DEVICE_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_IP_ADDRESS): str,
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str
-    }
-)
+@config_entries.HANDLERS.register(DOMAIN)
+class FlowHandler(config_entries.ConfigFlow):
+    """Handle a config flow."""
 
-class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return TapoOptionsFlowHandler(config_entry)
+
     async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        return await self.async_step_auth()
+
+    async def async_step_auth(self, user_input=None):
+        """Confirm the setup."""
         errors = {}
+        host = ""
+        username = ""
+        password = ""
         if user_input is not None:
             try:
                 host = user_input[CONF_IP_ADDRESS]
@@ -48,5 +55,60 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     _LOGGER.error(e)
 
         return self.async_show_form(
-            step_id="user", data_schema=DEVICE_SCHEMA, errors=errors
+            step_id="auth", 
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_IP_ADDRESS, description={"suggested_value": host}): str,
+                    vol.Required(CONF_USERNAME, description={"suggested_value": username}): str,
+                    vol.Required(CONF_PASSWORD, description={"suggested_value": password}): str
+                }
+            ), 
+            errors=errors
+        )
+
+class TapoOptionsFlowHandler(config_entries.OptionsFlow):
+
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+
+    async def async_step_init(self, user_input=None):
+        """Manage the Tapo options."""
+        return await self.async_step_auth()
+
+    async def async_step_auth(self, user_input=None):
+        """Manage the Tapo options."""
+        errors = {}
+        username = self.config_entry.data[CONF_USERNAME]
+        password = self.config_entry.data[CONF_PASSWORD]
+        if user_input is not None:
+            try:
+                host = self.config_entry.data['ip_address']
+                username = user_input[CONF_USERNAME]
+                password = user_input[CONF_PASSWORD]
+
+                await self.hass.async_add_executor_job(registerController, host, username, password)
+
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data={CONF_IP_ADDRESS: host, CONF_USERNAME: username, CONF_PASSWORD: password,},
+                )
+                return self.async_create_entry(title="", data=None)
+            except Exception as e:
+                if("Failed to establish a new connection" in str(e)):
+                    errors["base"] = "connection_failed"
+                elif(str(e) == "Invalid authentication data."):
+                    errors["base"] = "invalid_auth"
+                else:
+                    errors["base"] = "unknown"
+                    _LOGGER.error(e)
+
+        return self.async_show_form(
+            step_id="auth",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME, description={"suggested_value": username}): str,
+                    vol.Required(CONF_PASSWORD, description={"suggested_value": password}): str
+                }
+            ),
+            errors=errors,
         )

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -5,12 +5,8 @@ from homeassistant.const import (
     CONF_PASSWORD
 )
 import voluptuous as vol
-import logging
 from .utils import registerController
-
-from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .const import *
 
 @config_entries.HANDLERS.register(DOMAIN)
 class FlowHandler(config_entries.ConfigFlow):
@@ -52,7 +48,7 @@ class FlowHandler(config_entries.ConfigFlow):
                     errors["base"] = "invalid_auth"
                 else:
                     errors["base"] = "unknown"
-                    _LOGGER.error(e)
+                    LOGGER.error(e)
 
         return self.async_show_form(
             step_id="auth", 
@@ -100,7 +96,7 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
                     errors["base"] = "invalid_auth"
                 else:
                     errors["base"] = "unknown"
-                    _LOGGER.error(e)
+                    LOGGER.error(e)
 
         return self.async_show_form(
             step_id="auth",

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -12,7 +12,7 @@ from .const import *
 class FlowHandler(config_entries.ConfigFlow):
     """Handle a config flow."""
 
-    VERSION = 1
+    VERSION = 2
 
     @staticmethod
     def async_get_options_flow(config_entry):
@@ -29,17 +29,19 @@ class FlowHandler(config_entries.ConfigFlow):
         host = ""
         username = ""
         password = ""
+        enable_motion_sensor = True
         if user_input is not None:
             try:
                 host = user_input[CONF_IP_ADDRESS]
                 username = user_input[CONF_USERNAME]
                 password = user_input[CONF_PASSWORD]
+                enable_motion_sensor = user_input[ENABLE_MOTION_SENSOR]
 
                 await self.hass.async_add_executor_job(registerController, host, username, password)
 
                 return self.async_create_entry(
                     title=host,
-                    data={CONF_IP_ADDRESS: host, CONF_USERNAME: username, CONF_PASSWORD: password,},
+                    data={ENABLE_MOTION_SENSOR: enable_motion_sensor, CONF_IP_ADDRESS: host, CONF_USERNAME: username, CONF_PASSWORD: password,},
                 )
             except Exception as e:
                 if("Failed to establish a new connection" in str(e)):
@@ -56,7 +58,8 @@ class FlowHandler(config_entries.ConfigFlow):
                 {
                     vol.Required(CONF_IP_ADDRESS, description={"suggested_value": host}): str,
                     vol.Required(CONF_USERNAME, description={"suggested_value": username}): str,
-                    vol.Required(CONF_PASSWORD, description={"suggested_value": password}): str
+                    vol.Required(CONF_PASSWORD, description={"suggested_value": password}): str,
+                    vol.Required(ENABLE_MOTION_SENSOR, description={"suggested_value": enable_motion_sensor}): bool
                 }
             ), 
             errors=errors
@@ -77,16 +80,18 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
         errors = {}
         username = self.config_entry.data[CONF_USERNAME]
         password = self.config_entry.data[CONF_PASSWORD]
+        enable_motion_sensor = self.config_entry.data[ENABLE_MOTION_SENSOR]
         if user_input is not None:
             try:
                 host = self.config_entry.data['ip_address']
                 username = user_input[CONF_USERNAME]
                 password = user_input[CONF_PASSWORD]
+                enable_motion_sensor = user_input[ENABLE_MOTION_SENSOR]
 
                 await self.hass.async_add_executor_job(registerController, host, username, password)
 
                 self.hass.config_entries.async_update_entry(
-                    self.config_entry, data={CONF_IP_ADDRESS: host, CONF_USERNAME: username, CONF_PASSWORD: password,},
+                    self.config_entry, data={ENABLE_MOTION_SENSOR: enable_motion_sensor, CONF_IP_ADDRESS: host, CONF_USERNAME: username, CONF_PASSWORD: password,},
                 )
                 return self.async_create_entry(title="", data=None)
             except Exception as e:
@@ -103,7 +108,8 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_USERNAME, description={"suggested_value": username}): str,
-                    vol.Required(CONF_PASSWORD, description={"suggested_value": password}): str
+                    vol.Required(CONF_PASSWORD, description={"suggested_value": password}): str,
+                    vol.Required(ENABLE_MOTION_SENSOR, description={"suggested_value": enable_motion_sensor}): bool
                 }
             ),
             errors=errors,

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -1,4 +1,5 @@
 import voluptuous as vol
+import logging
 from datetime import timedelta
 from homeassistant.helpers import config_validation as cv
 
@@ -87,3 +88,5 @@ SERVICE_FORMAT = "format"
 SCHEMA_SERVICE_FORMAT = {
     vol.Required(ENTITY_ID): cv.string
 }
+
+LOGGER = logging.getLogger("custom_components."+DOMAIN)

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -24,6 +24,8 @@ DEVICE_MODEL_C200 = "C200"
 DEVICES_WITH_NO_PRESETS = [DEVICE_MODEL_C100]
 SCAN_INTERVAL = timedelta(seconds=5)
 
+ENABLE_MOTION_SENSOR = "enable_motion_sensor"
+
 TOGGLE_STATES = ["on", "off"]
 
 SERVICE_PTZ = "ptz"

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -1,20 +1,37 @@
 {
-  "title": "Tapo: Cameras Control",
-  "config": {
-    "step": {
-      "user": {
-        "title": "Connect Tapo camera",
-        "data": {
-          "ip_address": "IP Address",
-          "username": "Username",
-          "password": "Password"
-        }
-      }
-    },
-    "error": {
-      "invalid_auth": "Invalid authentication data",
-      "unknown": "Unknown error",
-      "connection_failed": "Connection failed"
-    }
-  }
+	"title": "Tapo: Cameras Control",
+	"config": {
+		"step": {
+			"auth": {
+				"data": {
+					"ip_address": "IP Address",
+					"username": "Username",
+					"password": "Password"
+				},
+				"description": "Please enter the connection information of your Tapo camera."
+			}
+		},
+		"error": {
+			"invalid_auth": "Invalid authentication data",
+			"unknown": "Unknown error",
+			"connection_failed": "Connection failed"
+		}
+	},
+	"options": {
+		"step": {
+			"auth": {
+				"data": {
+					"ip_address": "IP Address",
+					"username": "Username",
+					"password": "Password"
+                },
+                "description": "Please enter the connection information of your Tapo camera."
+			}
+		},
+		"error": {
+			"invalid_auth": "Invalid authentication data",
+			"unknown": "Unknown error",
+			"connection_failed": "Connection failed"
+		}
+	}
 }

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -6,7 +6,8 @@
 				"data": {
 					"ip_address": "IP Address",
 					"username": "Username",
-					"password": "Password"
+					"password": "Password",
+                    "enable_motion_sensor": "Enable motion sensor"
 				},
 				"description": "Please enter the connection information of your Tapo camera."
 			}
@@ -23,7 +24,8 @@
 				"data": {
 					"ip_address": "IP Address",
 					"username": "Username",
-					"password": "Password"
+                    "password": "Password",
+                    "enable_motion_sensor": "Enable motion sensor"
                 },
                 "description": "Please enter the connection information of your Tapo camera."
 			}

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -1,21 +1,37 @@
 {
-    "title": "Tapo: Cameras Control",
-    "config": {
-      "step": {
-        "user": {
-          "title": "Connect Tapo camera",
-          "data": {
-            "ip_address": "IP Address",
-            "username": "Username",
-            "password": "Password"
-          }
-        }
-      },
-      "error": {
-        "invalid_auth": "Invalid authentication data",
-        "unknown": "Unknown error",
-        "connection_failed": "Connection failed"
-      }
-    }
-  }
-  
+	"title": "Tapo: Cameras Control",
+	"config": {
+		"step": {
+			"auth": {
+				"data": {
+					"ip_address": "IP Address",
+					"username": "Username",
+					"password": "Password"
+				},
+				"description": "Please enter the connection information of your Tapo camera."
+			}
+		},
+		"error": {
+			"invalid_auth": "Invalid authentication data",
+			"unknown": "Unknown error",
+			"connection_failed": "Connection failed"
+		}
+	},
+	"options": {
+		"step": {
+			"auth": {
+				"data": {
+					"ip_address": "IP Address",
+					"username": "Username",
+					"password": "Password"
+                },
+                "description": "Please enter the connection information of your Tapo camera."
+			}
+		},
+		"error": {
+			"invalid_auth": "Invalid authentication data",
+			"unknown": "Unknown error",
+			"connection_failed": "Connection failed"
+		}
+	}
+}

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -6,7 +6,8 @@
 				"data": {
 					"ip_address": "IP Address",
 					"username": "Username",
-					"password": "Password"
+					"password": "Password",
+                    "enable_motion_sensor": "Enable motion sensor"
 				},
 				"description": "Please enter the connection information of your Tapo camera."
 			}
@@ -23,7 +24,8 @@
 				"data": {
 					"ip_address": "IP Address",
 					"username": "Username",
-					"password": "Password"
+                    "password": "Password",
+                    "enable_motion_sensor": "Enable motion sensor"
                 },
                 "description": "Please enter the connection information of your Tapo camera."
 			}


### PR DESCRIPTION
This release is all about the quality of life improvements.

# New features
- Change authentication data and other options via Tapo Integration Options. 
- Disable / Enable camera entities via Home Assistant entity manager (make sure not to disable motion sensor via entity, check [troubleshooting](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control#troubleshooting) if you did). 
- Disable / Enable motion detection (= the whole onvif connection) via Tapo Integration Options.

**No reboot required!**

# Other minor changes and fixes
- When an error occurs while adding or updating the camera in integration page, the inputs do not lose entered values
- Other minor fixes

# Pictures
![image](https://user-images.githubusercontent.com/5785999/96321003-56685300-1014-11eb-968d-a50d6b34359f.png)
![image](https://user-images.githubusercontent.com/5785999/96321067-7566e500-1014-11eb-86a2-45bba3d644e8.png)