### PR TITLE
Added two more template switches to the examples

### DIFF
--- a/examples/EXAMPLES_ENTITIES.md
+++ b/examples/EXAMPLES_ENTITIES.md
@@ -7,15 +7,19 @@ Below you can find some examples of usage of this custom component in template e
 - See [documentation for template binary sensor](https://www.home-assistant.io/integrations/binary_sensor.template/)
 - See [documentation for template sensor](https://www.home-assistant.io/integrations/template/)
 
-### Control privacy mode via switch
+### Control `Privacy Mode`, `Auto Track`, `Alarm Mode` with template switches
 
 Add to your configuration.yaml:
 
 ```yaml
+# configuration.yaml
+
 switch:
   - platform: template
     switches:
-      bedroom_privacy_mode:
+      # This is a switch to turn the privacy mode on/off
+      bedroom_privacy_mode_switch:
+        friendly_name: Privacy Mode
         value_template: "{{ state_attr('camera.bedroom_hd', 'privacy_mode') == 'on' }}"
         turn_on:
           service: tapo_control.set_privacy_mode
@@ -27,6 +31,47 @@ switch:
           data:
             entity_id: "camera.bedroom_hd"
             privacy_mode: "off"
+        icon_template: >-
+          {% if state_attr('camera.bedroom_hd', 'privacy_mode') == 'on' %}
+            mdi:eye-off-outline
+          {% else %}
+            mdi:eye-outline
+          {% endif %}
+      # This is a switch to turn the auto track mode on/off
+      bedroom_auto_track_switch:
+        friendly_name: Auto Track
+        value_template: "{{ state_attr('camera.bedroom_hd', 'auto_track') == 'on' }}"
+        turn_on:
+          - service: tapo_control.set_auto_track_mode
+            data:
+              entity_id: camera.bedroom_hd
+              auto_track_mode: 'on'
+        turn_off:
+          - service: tapo_control.set_auto_track_mode
+            data:
+              entity_id: camera.bedroom_hd
+              auto_track_mode: 'off'
+        icon_template: "mdi:radar"
+      # This is a switch to turn the alarm on/off
+      bedroom_alarm_switch:
+        friendly_name: Alarm
+        value_template: "{{ state_attr('camera.bedroom_hd', 'alarm') == 'on' }}"
+        turn_on:
+          - service: tapo_control.set_alarm_mode
+            data:
+              entity_id: camera.bedroom_hd
+              alarm_mode: 'on'
+        turn_off:
+          - service: tapo_control.set_alarm_mode
+            data:
+              entity_id: camera.bedroom_hd
+              alarm_mode: 'off'
+        icon_template: >-
+          {% if state_attr('camera.bedroom_hd', 'alarm') == 'on' %}
+            mdi:alarm-note
+          {% else %}
+            mdi:alarm-note-off
+          {% endif %}
 ```
 
 After refresh, switch will be available as switch.bedroom_privacy_mode.

--- a/examples/EXAMPLES_ENTITIES.md
+++ b/examples/EXAMPLES_ENTITIES.md
@@ -18,7 +18,7 @@ switch:
   - platform: template
     switches:
       # This is a switch to turn the privacy mode on/off
-      bedroom_privacy_mode_switch:
+      bedroom_privacy_mode:
         friendly_name: Privacy Mode
         value_template: "{{ state_attr('camera.bedroom_hd', 'privacy_mode') == 'on' }}"
         turn_on:
@@ -38,7 +38,7 @@ switch:
             mdi:eye-outline
           {% endif %}
       # This is a switch to turn the auto track mode on/off
-      bedroom_auto_track_switch:
+      bedroom_auto_track:
         friendly_name: Auto Track
         value_template: "{{ state_attr('camera.bedroom_hd', 'auto_track') == 'on' }}"
         turn_on:
@@ -53,7 +53,7 @@ switch:
               auto_track_mode: 'off'
         icon_template: "mdi:radar"
       # This is a switch to turn the alarm on/off
-      bedroom_alarm_switch:
+      bedroom_alarm:
         friendly_name: Alarm
         value_template: "{{ state_attr('camera.bedroom_hd', 'alarm') == 'on' }}"
         turn_on:


### PR DESCRIPTION
Just two more examples with icon-template and friendly name like 

```yaml
bedroom_privacy_mode_switch:
  friendly_name: Privacy Mode
  value_template: [...]
  turn_on: [...]
  turn_off: [...]
  icon_template: >-
    {% if state_attr('camera.bedroom_hd', 'privacy_mode') == 'on' %}
      mdi:eye-off-outline
    {% else %}
      mdi:eye-outline
    {% endif %}
```