### PR TITLE
2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ Also make sure that:
 - onvif port 2020 on camera is opened
 </details>
 
+<details>
+  <summary>There is a big delay in video stream</summary>
+
+This is a [known issue](https://community.home-assistant.io/t/i-tried-all-the-camera-platforms-so-you-dont-have-to/222999) of Home Assistant.
+
+There is an ability to disable usage of Home Assistant Stream component for the camera, which might lower the delay very significantly.
+
+You can choose to disable stream component when adding the camera, or via Options when camera has already been added. This change requires a restart of Home Assistant.
+
+There might be some disadvantages to doing this, like losing option to control playback, and which depend on your environment and future Home Assistant updates.
+
+Try it out and see what works best for you.
+
+If you encounter any issues worth mentioning here while not using a stream component, please report them via a new issue or a PR.
+
+</details>
+
 ## Have a comment or a suggestion?
 
 Please [open a new issue](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/new/choose), or discuss on [Home Assistant: Community Forum](https://community.home-assistant.io/t/tapo-cameras-control/231795).

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -8,12 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from .const import (
-    LOGGER,
-    DOMAIN,
-    ENABLE_MOTION_SENSOR,
-    CLOUD_PASSWORD,
-)
+from .const import LOGGER, DOMAIN, ENABLE_MOTION_SENSOR, CLOUD_PASSWORD, ENABLE_STREAM
 from .utils import (
     registerController,
     getCamData,
@@ -50,6 +45,15 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         config_entry.data = {**new}
 
         config_entry.version = 3
+
+    if config_entry.version == 3:
+
+        new = {**config_entry.data}
+        new[ENABLE_STREAM] = True
+
+        config_entry.data = {**new}
+
+        config_entry.version = 4
 
     LOGGER.info("Migration to version %s successful", config_entry.version)
 
@@ -115,10 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                         entity.async_schedule_update_ha_state(True)
 
         tapoCoordinator = DataUpdateCoordinator(
-            hass,
-            LOGGER,
-            name="Tapo resource status",
-            update_method=async_update_data,
+            hass, LOGGER, name="Tapo resource status", update_method=async_update_data,
         )
 
         camData = await getCamData(hass, tapoController)

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -91,4 +91,6 @@ SCHEMA_SERVICE_DELETE_PRESET = {
 SERVICE_FORMAT = "format"
 SCHEMA_SERVICE_FORMAT = {vol.Required(ENTITY_ID): cv.string}
 
+ENABLE_STREAM = "enable_stream"
+
 LOGGER = logging.getLogger("custom_components." + DOMAIN)

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -1,39 +1,57 @@
 {
-	"title": "Tapo: Cameras Control",
-	"config": {
-		"step": {
-			"auth": {
-				"data": {
-					"ip_address": "IP Address",
-					"username": "Username",
-					"password": "Password",
-                    "enable_motion_sensor": "Enable motion sensor"
-				},
-				"description": "Please enter the connection information of your Tapo camera."
-			}
-		},
-		"error": {
-			"invalid_auth": "Invalid authentication data",
-			"unknown": "Unknown error",
-			"connection_failed": "Connection failed"
-		}
-	},
-	"options": {
-		"step": {
-			"auth": {
-				"data": {
-					"ip_address": "IP Address",
-					"username": "Username",
-                    "password": "Password",
-                    "enable_motion_sensor": "Enable motion sensor"
-                },
-                "description": "Please enter the connection information of your Tapo camera."
-			}
-		},
-		"error": {
-			"invalid_auth": "Invalid authentication data",
-			"unknown": "Unknown error",
-			"connection_failed": "Connection failed"
-		}
-	}
+  "title": "Tapo: Cameras Control",
+  "config": {
+    "step": {
+      "auth": {
+        "data": {
+          "ip_address": "IP Address",
+          "username": "Username",
+          "password": "Password"
+        },
+        "description": "Enter camera account credentials.\n\nThis account is created via Tapo app at:\nCamera Settings > Advanced Settings > Camera Account"
+      },
+      "auth_cloud_password": {
+        "data": {
+          "cloud_password": "Cloud Password"
+        },
+        "description": "Camera requires your cloud password for control.\nEmail is not needed and all communication is still fully local."
+      },
+      "other_options": {
+        "data": {
+          "enable_motion_sensor": "Enable motion sensor",
+          "enable_stream": "Use Stream from Home Assistant"
+        },
+        "description": "Almost there!\nJust some final options..."
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid authentication data",
+      "unknown": "Unknown error",
+      "connection_failed": "Connection failed",
+      "invalid_auth_cloud": "Invalid cloud password",
+      "camera_requires_admin": "Your camera requires cloud password for control"
+    }
+  },
+  "options": {
+    "step": {
+      "auth": {
+        "data": {
+          "ip_address": "IP Address",
+          "username": "Username",
+          "password": "Password",
+          "enable_motion_sensor": "Enable motion sensor",
+          "enable_stream": "Use Stream from Home Assistant [requires restart]",
+          "cloud_password": "Cloud Password (Optional)"
+        },
+        "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes (recommended) - Longer playback delay, Lovelace card smooth playback\nNo - Instant playback once opened, Lovelace card 10 second image refresh"
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid authentication data",
+      "unknown": "Unknown error",
+      "connection_failed": "Connection failed",
+      "invalid_auth_cloud": "Invalid cloud password",
+      "camera_requires_admin": "Camera requires cloud password for control"
+    }
+  }
 }

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -43,7 +43,7 @@
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
           "cloud_password": "Cloud Password (Optional)"
         },
-        "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes (recommended) - Longer playback delay, Lovelace card smooth playback\nNo - Instant playback once opened, Lovelace card 10 second image refresh"
+        "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, allows playback control\nNo - Very short playback delay, no playback control"
       }
     },
     "error": {

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -1,55 +1,57 @@
 {
-	"title": "Tapo: Cameras Control",
-	"config": {
-		"step": {
-			"auth": {
-				"data": {
-					"ip_address": "IP Address",
-					"username": "Username",
-					"password": "Password"
-				},
-				"description": "Enter camera account credentials.\n\nThis account is created via Tapo app at:\nCamera Settings > Advanced Settings > Camera Account"
-			},
-			"auth_cloud_password": {
-				"data": {
-                    "cloud_password": "Cloud Password"
-				},
-				"description": "Camera requires your cloud password for control.\nEmail is not needed and all communication is still fully local."
-			},
-			"other_options": {
-				"data": {
-                    "enable_motion_sensor": "Enable motion sensor"
-				},
-				"description": "Almost there!\nJust some final options..."
-			}
-		},
-		"error": {
-			"invalid_auth": "Invalid authentication data",
-			"unknown": "Unknown error",
-			"connection_failed": "Connection failed",
-			"invalid_auth_cloud": "Invalid cloud password",
-			"camera_requires_admin": "Your camera requires cloud password for control"
-		}
-	},
-	"options": {
-		"step": {
-			"auth": {
-				"data": {
-					"ip_address": "IP Address",
-					"username": "Username",
-                    "password": "Password",
-                    "enable_motion_sensor": "Enable motion sensor",
-                    "cloud_password": "Cloud Password (Optional)"
-                },
-                "description": "Please enter the connection information of your Tapo camera."
-			}
-		},
-		"error": {
-			"invalid_auth": "Invalid authentication data",
-			"unknown": "Unknown error",
-			"connection_failed": "Connection failed",
-			"invalid_auth_cloud": "Invalid cloud password",
-			"camera_requires_admin": "Camera requires cloud password for control"
-		}
-	}
+  "title": "Tapo: Cameras Control",
+  "config": {
+    "step": {
+      "auth": {
+        "data": {
+          "ip_address": "IP Address",
+          "username": "Username",
+          "password": "Password"
+        },
+        "description": "Enter camera account credentials.\n\nThis account is created via Tapo app at:\nCamera Settings > Advanced Settings > Camera Account"
+      },
+      "auth_cloud_password": {
+        "data": {
+          "cloud_password": "Cloud Password"
+        },
+        "description": "Camera requires your cloud password for control.\nEmail is not needed and all communication is still fully local."
+      },
+      "other_options": {
+        "data": {
+          "enable_motion_sensor": "Enable motion sensor",
+          "enable_stream": "Use Stream from Home Assistant"
+        },
+        "description": "Almost there!\nJust some final options..."
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid authentication data",
+      "unknown": "Unknown error",
+      "connection_failed": "Connection failed",
+      "invalid_auth_cloud": "Invalid cloud password",
+      "camera_requires_admin": "Your camera requires cloud password for control"
+    }
+  },
+  "options": {
+    "step": {
+      "auth": {
+        "data": {
+          "ip_address": "IP Address",
+          "username": "Username",
+          "password": "Password",
+          "enable_motion_sensor": "Enable motion sensor",
+          "enable_stream": "Use Stream from Home Assistant [requires restart]",
+          "cloud_password": "Cloud Password (Optional)"
+        },
+        "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes (recommended) - Longer playback delay, Lovelace card smooth playback\nNo - Very short delay once opened, Lovelace card 10 sec image refresh"
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid authentication data",
+      "unknown": "Unknown error",
+      "connection_failed": "Connection failed",
+      "invalid_auth_cloud": "Invalid cloud password",
+      "camera_requires_admin": "Camera requires cloud password for control"
+    }
+  }
 }

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -43,7 +43,7 @@
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
           "cloud_password": "Cloud Password (Optional)"
         },
-        "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes (recommended) - Longer playback delay, Lovelace card smooth playback\nNo - Very short delay once opened, Lovelace card 10 sec image refresh"
+        "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, allows playback control\nNo - Very short playback delay, no playback control"
       }
     },
     "error": {


### PR DESCRIPTION
# Version 2.4 🚀

## Description

This release adds an option for a user to choose to use stream component which when disabled, might provide a lot shorter playback delays for some users. Defaults to enabled.

There are advantages and disadvantages to both.
Enabled - Bigger delay, but player has an ability to stop, rewind etc. This is the default and recommended behaviour of Home Assistant if stream is enabled in configuration. More info: https://www.home-assistant.io/integrations/stream/
Disabled - A lot shorter delay, but no controls over playback. 

Addresses issues https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/54 and https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/37.

This is a [known issue](https://community.home-assistant.io/t/i-tried-all-the-camera-platforms-so-you-dont-have-to/222999) of Home Assistant.

There might be some other disadvantages to disabling the stream component for the camera, like losing option to control playback, and which depend on your environment and future Home Assistant updates.

Try it out and see what works best for you.

If you encounter any issues worth mentioning in readme while **not using** a stream component for the camera, please report them via a [new issue](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/new/choose) or a PR.

## Breaking changes

None. Your settings will be automatically migrated properly and the behaviour of the camera stays the same.