### PR TITLE
Version 3.1 🕐

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1,3 +1,4 @@
+import datetime
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_USERNAME,
@@ -15,6 +16,7 @@ from .const import (
     CLOUD_PASSWORD,
     ENABLE_STREAM,
     ENABLE_TIME_SYNC,
+    TIME_SYNC_PERIOD,
 )
 from .utils import (
     registerController,
@@ -22,6 +24,8 @@ from .utils import (
     setupOnvif,
     setupEvents,
     update_listener,
+    initOnvifEvents,
+    syncTime,
 )
 
 
@@ -92,6 +96,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     password = entry.data.get(CONF_PASSWORD)
     motionSensor = entry.data.get(ENABLE_MOTION_SENSOR)
     cloud_password = entry.data.get(CLOUD_PASSWORD)
+    enableTimeSync = entry.data.get(ENABLE_TIME_SYNC)
 
     try:
         if cloud_password != "":
@@ -108,17 +113,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             username = entry.data.get(CONF_USERNAME)
             password = entry.data.get(CONF_PASSWORD)
             motionSensor = entry.data.get(ENABLE_MOTION_SENSOR)
+            enableTimeSync = entry.data.get(ENABLE_TIME_SYNC)
 
             # motion detection retries
-            if motionSensor:
-                if not hass.data[DOMAIN][entry.entry_id]["eventsDevice"]:
+            if motionSensor or enableTimeSync:
+                if (
+                    not hass.data[DOMAIN][entry.entry_id]["eventsDevice"]
+                    or not hass.data[DOMAIN][entry.entry_id]["onvifManagement"]
+                ):
                     # retry if connection to onvif failed
-                    await setupOnvif(hass, entry, host, username, password)
-                elif not hass.data[DOMAIN][entry.entry_id]["eventsSetup"]:
+                    onvifDevice = await initOnvifEvents(hass, host, username, password)
+                    hass.data[DOMAIN][entry.entry_id]["eventsDevice"] = onvifDevice[
+                        "device"
+                    ]
+                    hass.data[DOMAIN][entry.entry_id]["onvifManagement"] = onvifDevice[
+                        "device_mgmt"
+                    ]
+                    if motionSensor:
+                        await setupOnvif(hass, entry)
+                elif (
+                    not hass.data[DOMAIN][entry.entry_id]["eventsSetup"]
+                    and motionSensor
+                ):
                     # retry if subscription to events failed
                     hass.data[DOMAIN][entry.entry_id][
                         "eventsSetup"
                     ] = await setupEvents(hass, entry)
+
+                if (
+                    hass.data[DOMAIN][entry.entry_id]["onvifManagement"]
+                    and enableTimeSync
+                ):
+                    ts = datetime.datetime.utcnow().timestamp()
+                    if (
+                        ts - hass.data[DOMAIN][entry.entry_id]["lastTimeSync"]
+                        > TIME_SYNC_PERIOD
+                    ):
+                        await syncTime(hass, entry)
 
             # cameras state
             someCameraEnabled = False
@@ -145,14 +176,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "update_listener": entry.add_update_listener(update_listener),
             "coordinator": tapoCoordinator,
             "camData": camData,
+            "lastTimeSync": 0,
             "motionSensorCreated": False,
             "eventsDevice": False,
+            "onvifManagement": False,
             "eventsSetup": False,
             "events": False,
             "name": camData["basic_info"]["device_alias"],
         }
-        if motionSensor:
-            await setupOnvif(hass, entry, host, username, password)
+        if motionSensor or enableTimeSync:
+            onvifDevice = await initOnvifEvents(hass, host, username, password)
+            hass.data[DOMAIN][entry.entry_id]["eventsDevice"] = onvifDevice["device"]
+            hass.data[DOMAIN][entry.entry_id]["onvifManagement"] = onvifDevice[
+                "device_mgmt"
+            ]
+            if motionSensor:
+                await setupOnvif(hass, entry)
+            if enableTimeSync:
+                await syncTime(hass, entry)
 
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, "camera")

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -8,7 +8,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from .const import LOGGER, DOMAIN, ENABLE_MOTION_SENSOR, CLOUD_PASSWORD, ENABLE_STREAM
+from .const import (
+    LOGGER,
+    DOMAIN,
+    ENABLE_MOTION_SENSOR,
+    CLOUD_PASSWORD,
+    ENABLE_STREAM,
+    ENABLE_TIME_SYNC,
+)
 from .utils import (
     registerController,
     getCamData,
@@ -54,6 +61,15 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         config_entry.data = {**new}
 
         config_entry.version = 4
+
+    if config_entry.version == 4:
+
+        new = {**config_entry.data}
+        new[ENABLE_TIME_SYNC] = False
+
+        config_entry.data = {**new}
+
+        config_entry.version = 5
 
     LOGGER.info("Migration to version %s successful", config_entry.version)
 

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -10,6 +10,7 @@ from .const import (
     ENABLE_STREAM,
     LOGGER,
     CLOUD_PASSWORD,
+    ENABLE_TIME_SYNC,
 )
 
 
@@ -17,7 +18,7 @@ from .const import (
 class FlowHandler(config_entries.ConfigFlow):
     """Handle a config flow."""
 
-    VERSION = 4
+    VERSION = 5
 
     @staticmethod
     def async_get_options_flow(config_entry):
@@ -63,9 +64,11 @@ class FlowHandler(config_entries.ConfigFlow):
         errors = {}
         enable_motion_sensor = True
         enable_stream = True
+        enable_time_sync = False
         if user_input is not None:
             enable_motion_sensor = user_input[ENABLE_MOTION_SENSOR]
             enable_stream = user_input[ENABLE_STREAM]
+            enable_time_sync = user_input[ENABLE_TIME_SYNC]
             host = self.tapoHost
             cloud_password = self.tapoCloudPassword
             username = self.tapoUsername
@@ -75,6 +78,7 @@ class FlowHandler(config_entries.ConfigFlow):
                 data={
                     ENABLE_MOTION_SENSOR: enable_motion_sensor,
                     ENABLE_STREAM: enable_stream,
+                    ENABLE_TIME_SYNC: enable_time_sync,
                     CONF_IP_ADDRESS: host,
                     CONF_USERNAME: username,
                     CONF_PASSWORD: password,
@@ -86,11 +90,15 @@ class FlowHandler(config_entries.ConfigFlow):
             step_id="other_options",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
+                    vol.Optional(
                         ENABLE_MOTION_SENSOR,
                         description={"suggested_value": enable_motion_sensor},
                     ): bool,
-                    vol.Required(
+                    vol.Optional(
+                        ENABLE_TIME_SYNC,
+                        description={"suggested_value": enable_time_sync},
+                    ): bool,
+                    vol.Optional(
                         ENABLE_STREAM, description={"suggested_value": enable_stream},
                     ): bool,
                 }
@@ -262,6 +270,7 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
         cloud_password = self.config_entry.data[CLOUD_PASSWORD]
         enable_motion_sensor = self.config_entry.data[ENABLE_MOTION_SENSOR]
         enable_stream = self.config_entry.data[ENABLE_STREAM]
+        enable_time_sync = self.config_entry.data[ENABLE_TIME_SYNC]
         if user_input is not None:
             try:
                 host = self.config_entry.data[CONF_IP_ADDRESS]
@@ -283,12 +292,17 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
                 if ENABLE_MOTION_SENSOR in user_input:
                     enable_motion_sensor = user_input[ENABLE_MOTION_SENSOR]
                 else:
-                    enable_motion_sensor = True
+                    enable_motion_sensor = False
 
                 if ENABLE_STREAM in user_input:
                     enable_stream = user_input[ENABLE_STREAM]
                 else:
-                    enable_stream = True
+                    enable_stream = False
+
+                if ENABLE_TIME_SYNC in user_input:
+                    enable_time_sync = user_input[ENABLE_TIME_SYNC]
+                else:
+                    enable_time_sync = False
 
                 rtspStreamWorks = await isRtspStreamWorking(
                     self.hass, host, username, password
@@ -315,6 +329,7 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_USERNAME: username,
                         CONF_PASSWORD: password,
                         CLOUD_PASSWORD: cloud_password,
+                        ENABLE_TIME_SYNC: enable_time_sync,
                     },
                 )
                 return self.async_create_entry(title="", data=None)
@@ -349,9 +364,14 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
                         description={"suggested_value": enable_motion_sensor},
                     ): bool,
                     vol.Optional(
+                        ENABLE_TIME_SYNC,
+                        description={"suggested_value": enable_time_sync},
+                    ): bool,
+                    vol.Optional(
                         ENABLE_STREAM, description={"suggested_value": enable_stream},
                     ): bool,
                 }
             ),
             errors=errors,
         )
+

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -96,3 +96,5 @@ ENABLE_STREAM = "enable_stream"
 ENABLE_TIME_SYNC = "enable_time_sync"
 
 LOGGER = logging.getLogger("custom_components." + DOMAIN)
+
+TIME_SYNC_PERIOD = 3600

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -93,4 +93,6 @@ SCHEMA_SERVICE_FORMAT = {vol.Required(ENTITY_ID): cv.string}
 
 ENABLE_STREAM = "enable_stream"
 
+ENABLE_TIME_SYNC = "enable_time_sync"
+
 LOGGER = logging.getLogger("custom_components." + DOMAIN)

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -25,6 +25,7 @@
       "other_options": {
         "data": {
           "enable_motion_sensor": "Enable motion sensor",
+          "enable_time_sync": "Automatically synchronize time",
           "enable_stream": "Use Stream from Home Assistant"
         },
         "description": "Almost there!\nJust some final options..."
@@ -54,6 +55,7 @@
           "password": "Password",
           "enable_motion_sensor": "Enable motion sensor",
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
+          "enable_time_sync": "Automatically synchronize time",
           "cloud_password": "Cloud Password (Optional)"
         },
         "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, lower CPU usage, allows playback control\nNo - Very short playback delay, higher CPU usage, no playback control"

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -25,7 +25,7 @@
       "other_options": {
         "data": {
           "enable_motion_sensor": "Enable motion sensor",
-          "enable_time_sync": "Automatically synchronize time",
+          "enable_time_sync": "Automatically synchronise time",
           "enable_stream": "Use Stream from Home Assistant"
         },
         "description": "Almost there!\nJust some final options..."
@@ -55,7 +55,7 @@
           "password": "Password",
           "enable_motion_sensor": "Enable motion sensor",
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
-          "enable_time_sync": "Automatically synchronize time",
+          "enable_time_sync": "Automatically synchronise time",
           "cloud_password": "Cloud Password (Optional)"
         },
         "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, lower CPU usage, allows playback control\nNo - Very short playback delay, higher CPU usage, no playback control"

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -25,6 +25,7 @@
       "other_options": {
         "data": {
           "enable_motion_sensor": "Enable motion sensor",
+          "enable_time_sync": "Automatically synchronize time",
           "enable_stream": "Use Stream from Home Assistant"
         },
         "description": "Almost there!\nJust some final options..."
@@ -54,6 +55,7 @@
           "password": "Password",
           "enable_motion_sensor": "Enable motion sensor",
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
+          "enable_time_sync": "Automatically synchronize time",
           "cloud_password": "Cloud Password (Optional)"
         },
         "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, lower CPU usage, allows playback control\nNo - Very short playback delay, higher CPU usage, no playback control"

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -25,7 +25,7 @@
       "other_options": {
         "data": {
           "enable_motion_sensor": "Enable motion sensor",
-          "enable_time_sync": "Automatically synchronize time",
+          "enable_time_sync": "Automatically synchronise time",
           "enable_stream": "Use Stream from Home Assistant"
         },
         "description": "Almost there!\nJust some final options..."
@@ -55,7 +55,7 @@
           "password": "Password",
           "enable_motion_sensor": "Enable motion sensor",
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
-          "enable_time_sync": "Automatically synchronize time",
+          "enable_time_sync": "Automatically synchronise time",
           "cloud_password": "Cloud Password (Optional)"
         },
         "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, lower CPU usage, allows playback control\nNo - Very short playback delay, higher CPU usage, no playback control"


### PR DESCRIPTION
# Version 3.1 🕐

## Description

This release adds a possibility to synchronise time with your cameras. This is especially useful when your camera does not have internet access, because the time gets desynchronised fairly quickly.

You will need to enable this feature, by going to your integrations, finding your camera under Tapo integration and opening Options. There will be a new option to **Automatically synchronise time**.

After turning on this option, camera will now automatically synchronise time on Home Assistant start (or on camera being added) and then every 1 hour.

## Breaking changes

None.