### PR TITLE
Version 3.3.0 🔊

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -109,6 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             )
 
         async def async_update_data():
+            print("async_update_data")
             host = entry.data.get(CONF_IP_ADDRESS)
             username = entry.data.get(CONF_USERNAME)
             password = entry.data.get(CONF_PASSWORD)
@@ -168,6 +169,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     if entity._enabled:
                         entity.updateCam(camData)
                         entity.async_schedule_update_ha_state(True)
+                        if not hass.data[DOMAIN][entry.entry_id]["noiseSensorStarted"]:
+                            print("STARTING")
+                            await entity._async_start_ffmpeg()
 
         tapoCoordinator = DataUpdateCoordinator(
             hass, LOGGER, name="Tapo resource status", update_method=async_update_data,

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -17,6 +17,9 @@ from .const import (
     CLOUD_PASSWORD,
     ENABLE_STREAM,
     ENABLE_TIME_SYNC,
+    SOUND_DETECTION_DURATION,
+    SOUND_DETECTION_PEAK,
+    SOUND_DETECTION_RESET,
     TIME_SYNC_PERIOD,
 )
 from .utils import (
@@ -80,6 +83,9 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 
         new = {**config_entry.data}
         new[ENABLE_SOUND_DETECTION] = False
+        new[SOUND_DETECTION_PEAK] = -50
+        new[SOUND_DETECTION_DURATION] = 1
+        new[SOUND_DETECTION_RESET] = 10
 
         config_entry.data = {**new}
 

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -46,6 +46,9 @@ from .const import (
     SCHEMA_SERVICE_FORMAT,
     DOMAIN,
     LOGGER,
+    SOUND_DETECTION_DURATION,
+    SOUND_DETECTION_PEAK,
+    SOUND_DETECTION_RESET,
     TILT,
     PAN,
     PRESET,
@@ -125,6 +128,9 @@ class TapoCamEntity(Camera):
         self._password = entry.data.get(CONF_PASSWORD)
         self._enable_stream = entry.data.get(ENABLE_STREAM)
         self._enable_sound_detection = entry.data.get(ENABLE_SOUND_DETECTION)
+        self._sound_detection_peak = entry.data.get(SOUND_DETECTION_PEAK)
+        self._sound_detection_duration = entry.data.get(SOUND_DETECTION_DURATION)
+        self._sound_detection_reset = entry.data.get(SOUND_DETECTION_RESET)
         self._attributes = tapoData["camData"]["basic_info"]
 
         self.updateCam(tapoData["camData"])
@@ -136,7 +142,9 @@ class TapoCamEntity(Camera):
                 self._ffmpeg.binary, self._noiseCallback
             )
             self._noiseSensor.set_options(
-                time_duration=1, time_reset=1, peak=-50,
+                time_duration=int(self._sound_detection_duration),
+                time_reset=int(self._sound_detection_reset),
+                peak=int(self._sound_detection_peak),
             )
 
     @callback

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -8,6 +8,7 @@ from .const import (
     DOMAIN,
     ENABLE_MOTION_SENSOR,
     ENABLE_STREAM,
+    ENABLE_SOUND_DETECTION,
     LOGGER,
     CLOUD_PASSWORD,
     ENABLE_TIME_SYNC,
@@ -65,6 +66,7 @@ class FlowHandler(config_entries.ConfigFlow):
         enable_motion_sensor = True
         enable_stream = True
         enable_time_sync = False
+        enable_sound_detection = False
         if user_input is not None:
             if ENABLE_MOTION_SENSOR in user_input:
                 enable_motion_sensor = user_input[ENABLE_MOTION_SENSOR]
@@ -74,6 +76,10 @@ class FlowHandler(config_entries.ConfigFlow):
                 enable_stream = user_input[ENABLE_STREAM]
             else:
                 enable_stream = False
+            if ENABLE_SOUND_DETECTION in user_input:
+                enable_sound_detection = user_input[ENABLE_SOUND_DETECTION]
+            else:
+                enable_sound_detection = False
             if ENABLE_TIME_SYNC in user_input:
                 enable_time_sync = user_input[ENABLE_TIME_SYNC]
             else:
@@ -87,6 +93,7 @@ class FlowHandler(config_entries.ConfigFlow):
                 data={
                     ENABLE_MOTION_SENSOR: enable_motion_sensor,
                     ENABLE_STREAM: enable_stream,
+                    ENABLE_SOUND_DETECTION: enable_sound_detection,
                     ENABLE_TIME_SYNC: enable_time_sync,
                     CONF_IP_ADDRESS: host,
                     CONF_USERNAME: username,
@@ -109,6 +116,10 @@ class FlowHandler(config_entries.ConfigFlow):
                     ): bool,
                     vol.Optional(
                         ENABLE_STREAM, description={"suggested_value": enable_stream},
+                    ): bool,
+                    vol.Optional(
+                        ENABLE_SOUND_DETECTION,
+                        description={"suggested_value": enable_sound_detection},
                     ): bool,
                 }
             ),
@@ -279,6 +290,7 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
         cloud_password = self.config_entry.data[CLOUD_PASSWORD]
         enable_motion_sensor = self.config_entry.data[ENABLE_MOTION_SENSOR]
         enable_stream = self.config_entry.data[ENABLE_STREAM]
+        enable_sound_detection = self.config_entry.data[ENABLE_SOUND_DETECTION]
         enable_time_sync = self.config_entry.data[ENABLE_TIME_SYNC]
         if user_input is not None:
             try:
@@ -308,6 +320,11 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
                 else:
                     enable_stream = False
 
+                if ENABLE_SOUND_DETECTION in user_input:
+                    enable_sound_detection = user_input[ENABLE_SOUND_DETECTION]
+                else:
+                    enable_sound_detection = False
+
                 if ENABLE_TIME_SYNC in user_input:
                     enable_time_sync = user_input[ENABLE_TIME_SYNC]
                 else:
@@ -334,6 +351,7 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
                     data={
                         ENABLE_STREAM: enable_stream,
                         ENABLE_MOTION_SENSOR: enable_motion_sensor,
+                        ENABLE_SOUND_DETECTION: enable_sound_detection,
                         CONF_IP_ADDRESS: host,
                         CONF_USERNAME: username,
                         CONF_PASSWORD: password,
@@ -378,6 +396,10 @@ class TapoOptionsFlowHandler(config_entries.OptionsFlow):
                     ): bool,
                     vol.Optional(
                         ENABLE_STREAM, description={"suggested_value": enable_stream},
+                    ): bool,
+                    vol.Optional(
+                        ENABLE_SOUND_DETECTION,
+                        description={"suggested_value": enable_sound_detection},
                     ): bool,
                 }
             ),

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -70,6 +70,9 @@ class FlowHandler(config_entries.ConfigFlow):
         enable_stream = True
         enable_time_sync = False
         enable_sound_detection = False
+        sound_detection_peak = -50
+        sound_detection_duration = 1
+        sound_detection_reset = 10
         if user_input is not None:
             if ENABLE_MOTION_SENSOR in user_input:
                 enable_motion_sensor = user_input[ENABLE_MOTION_SENSOR]
@@ -79,14 +82,26 @@ class FlowHandler(config_entries.ConfigFlow):
                 enable_stream = user_input[ENABLE_STREAM]
             else:
                 enable_stream = False
-            if ENABLE_SOUND_DETECTION in user_input:
-                enable_sound_detection = user_input[ENABLE_SOUND_DETECTION]
-            else:
-                enable_sound_detection = False
             if ENABLE_TIME_SYNC in user_input:
                 enable_time_sync = user_input[ENABLE_TIME_SYNC]
             else:
                 enable_time_sync = False
+            if ENABLE_SOUND_DETECTION in user_input:
+                enable_sound_detection = user_input[ENABLE_SOUND_DETECTION]
+            else:
+                enable_sound_detection = False
+            if SOUND_DETECTION_PEAK in user_input:
+                sound_detection_peak = user_input[SOUND_DETECTION_PEAK]
+            else:
+                sound_detection_peak = -50
+            if SOUND_DETECTION_DURATION in user_input:
+                sound_detection_duration = user_input[SOUND_DETECTION_DURATION]
+            else:
+                sound_detection_duration = -50
+            if SOUND_DETECTION_RESET in user_input:
+                sound_detection_reset = user_input[SOUND_DETECTION_RESET]
+            else:
+                sound_detection_reset = -50
             host = self.tapoHost
             cloud_password = self.tapoCloudPassword
             username = self.tapoUsername
@@ -96,12 +111,15 @@ class FlowHandler(config_entries.ConfigFlow):
                 data={
                     ENABLE_MOTION_SENSOR: enable_motion_sensor,
                     ENABLE_STREAM: enable_stream,
-                    ENABLE_SOUND_DETECTION: enable_sound_detection,
                     ENABLE_TIME_SYNC: enable_time_sync,
                     CONF_IP_ADDRESS: host,
                     CONF_USERNAME: username,
                     CONF_PASSWORD: password,
                     CLOUD_PASSWORD: cloud_password,
+                    ENABLE_SOUND_DETECTION: enable_sound_detection,
+                    SOUND_DETECTION_PEAK: sound_detection_peak,
+                    SOUND_DETECTION_DURATION: sound_detection_duration,
+                    SOUND_DETECTION_RESET: sound_detection_reset,
                 },
             )
 
@@ -124,6 +142,18 @@ class FlowHandler(config_entries.ConfigFlow):
                         ENABLE_SOUND_DETECTION,
                         description={"suggested_value": enable_sound_detection},
                     ): bool,
+                    vol.Optional(
+                        SOUND_DETECTION_PEAK,
+                        description={"suggested_value": sound_detection_peak},
+                    ): int,
+                    vol.Optional(
+                        SOUND_DETECTION_DURATION,
+                        description={"suggested_value": sound_detection_duration},
+                    ): int,
+                    vol.Optional(
+                        SOUND_DETECTION_RESET,
+                        description={"suggested_value": sound_detection_reset},
+                    ): int,
                 }
             ),
             errors=errors,

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -83,6 +83,9 @@ SCHEMA_SERVICE_FORMAT = {}
 
 ENABLE_STREAM = "enable_stream"
 ENABLE_SOUND_DETECTION = "enable_sound_detection"
+SOUND_DETECTION_PEAK = "sound_detection_peak"
+SOUND_DETECTION_DURATION = "sound_detection_duration"
+SOUND_DETECTION_RESET = "sound_detection_reset"
 
 ENABLE_TIME_SYNC = "enable_time_sync"
 

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -82,6 +82,7 @@ SERVICE_FORMAT = "format"
 SCHEMA_SERVICE_FORMAT = {}
 
 ENABLE_STREAM = "enable_stream"
+ENABLE_SOUND_DETECTION = "enable_sound_detection"
 
 ENABLE_TIME_SYNC = "enable_time_sync"
 

--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/JurajNyiri/HomeAssistant-Tapo-Control",
   "issue_tracker": "https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues",
   "codeowners": ["@JurajNyiri"],
-  "version": "3.2",
+  "version": "3.3",
   "requirements": [
     "pytapo==1.2.1",
     "onvif-zeep-async==1.0.0",

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -27,7 +27,10 @@
           "enable_motion_sensor": "Enable motion sensor",
           "enable_time_sync": "Automatically synchronise time",
           "enable_stream": "Use Stream from Home Assistant",
-          "enable_sound_detection": "Enable sound threshold detection"
+          "enable_sound_detection": "Enable sound threshold detection",
+          "sound_detection_peak": "[Sound Detection] Peak in dB. 0 is very loud and -100 is low.",
+          "sound_detection_duration": "[Sound Detection] How long the noise needs to be over the peak to trigger the state.",
+          "sound_detection_reset": "[Sound Detection] The time to reset the state after no new noise is over the peak."
         },
         "description": "Almost there!\nJust some final options..."
       }
@@ -40,7 +43,8 @@
       "connection_failed": "Connection failed",
       "invalid_auth_cloud": "Invalid cloud password",
       "camera_requires_admin": "Your camera requires cloud password for control",
-      "already_configured": "IP address already configured"
+      "already_configured": "IP address already configured",
+      "incorrect_peak_value": "Incorrect sound detection peak value."
     },
     "abort": {
       "already_configured": "IP address already configured",
@@ -58,6 +62,9 @@
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
           "enable_time_sync": "Automatically synchronise time",
           "enable_sound_detection": "Enable sound threshold detection",
+          "sound_detection_peak": "[Sound Detection] Peak in dB. 0 is very loud and -100 is low.",
+          "sound_detection_duration": "[Sound Detection] How long the noise needs to be over the peak to trigger the state.",
+          "sound_detection_reset": "[Sound Detection] The time to reset the state after no new noise is over the peak.",
           "cloud_password": "Cloud Password (Optional)"
         },
         "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, lower CPU usage, allows playback control\nNo - Very short playback delay, higher CPU usage, no playback control"
@@ -68,7 +75,8 @@
       "unknown": "Unknown error",
       "connection_failed": "Connection failed",
       "invalid_auth_cloud": "Invalid cloud password",
-      "camera_requires_admin": "Camera requires cloud password for control"
+      "camera_requires_admin": "Camera requires cloud password for control",
+      "incorrect_peak_value": "Incorrect sound detection peak value."
     }
   }
 }

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -26,7 +26,8 @@
         "data": {
           "enable_motion_sensor": "Enable motion sensor",
           "enable_time_sync": "Automatically synchronise time",
-          "enable_stream": "Use Stream from Home Assistant"
+          "enable_stream": "Use Stream from Home Assistant",
+          "enable_sound_detection": "Enable sound threshold detection"
         },
         "description": "Almost there!\nJust some final options..."
       }
@@ -56,6 +57,7 @@
           "enable_motion_sensor": "Enable motion sensor",
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
           "enable_time_sync": "Automatically synchronise time",
+          "enable_sound_detection": "Enable sound threshold detection",
           "cloud_password": "Cloud Password (Optional)"
         },
         "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, lower CPU usage, allows playback control\nNo - Very short playback delay, higher CPU usage, no playback control"

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -27,7 +27,10 @@
           "enable_motion_sensor": "Enable motion sensor",
           "enable_time_sync": "Automatically synchronise time",
           "enable_stream": "Use Stream from Home Assistant",
-          "enable_sound_detection": "Enable sound threshold detection"
+          "enable_sound_detection": "Enable sound threshold detection",
+          "sound_detection_peak": "[Sound Detection] Peak in dB. 0 is very loud and -100 is low.",
+          "sound_detection_duration": "[Sound Detection] How long the noise needs to be over the peak to trigger the state.",
+          "sound_detection_reset": "[Sound Detection] The time to reset the state after no new noise is over the peak."
         },
         "description": "Almost there!\nJust some final options..."
       }
@@ -40,7 +43,8 @@
       "connection_failed": "Connection failed",
       "invalid_auth_cloud": "Invalid cloud password",
       "camera_requires_admin": "Your camera requires cloud password for control",
-      "already_configured": "IP address already configured"
+      "already_configured": "IP address already configured",
+      "incorrect_peak_value": "Incorrect sound detection peak value."
     },
     "abort": {
       "already_configured": "IP address already configured",
@@ -58,7 +62,10 @@
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
           "enable_time_sync": "Automatically synchronise time",
           "enable_sound_detection": "Enable sound threshold detection",
-          "cloud_password": "Cloud Password (Optional)"
+          "cloud_password": "Cloud Password (Optional)",
+          "sound_detection_peak": "[Sound Detection] Peak in dB. 0 is very loud and -100 is low.",
+          "sound_detection_duration": "[Sound Detection] How long the noise needs to be over the peak to trigger the state.",
+          "sound_detection_reset": "[Sound Detection] The time to reset the state after no new noise is over the peak."
         },
         "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, lower CPU usage, allows playback control\nNo - Very short playback delay, higher CPU usage, no playback control"
       }
@@ -68,7 +75,8 @@
       "unknown": "Unknown error",
       "connection_failed": "Connection failed",
       "invalid_auth_cloud": "Invalid cloud password",
-      "camera_requires_admin": "Camera requires cloud password for control"
+      "camera_requires_admin": "Camera requires cloud password for control",
+      "incorrect_peak_value": "Incorrect sound detection peak value."
     }
   }
 }

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -26,7 +26,8 @@
         "data": {
           "enable_motion_sensor": "Enable motion sensor",
           "enable_time_sync": "Automatically synchronise time",
-          "enable_stream": "Use Stream from Home Assistant"
+          "enable_stream": "Use Stream from Home Assistant",
+          "enable_sound_detection": "Enable sound threshold detection"
         },
         "description": "Almost there!\nJust some final options..."
       }
@@ -56,6 +57,7 @@
           "enable_motion_sensor": "Enable motion sensor",
           "enable_stream": "Use Stream from Home Assistant [requires restart]",
           "enable_time_sync": "Automatically synchronise time",
+          "enable_sound_detection": "Enable sound threshold detection",
           "cloud_password": "Cloud Password (Optional)"
         },
         "description": "Modify settings of your Tapo Camera.\n\nUse stream from Home Assistant:\nYes - Longer playback delay, lower CPU usage, allows playback control\nNo - Very short playback delay, higher CPU usage, no playback control"

--- a/custom_components/tapo_control/translations/pt_BR.json
+++ b/custom_components/tapo_control/translations/pt_BR.json
@@ -26,7 +26,8 @@
         "data": {
           "enable_motion_sensor": "Habilitar sensor de movimento",
           "enable_time_sync": "Sincronizar Hora Automaticamente",
-          "enable_stream": "Usar stream do Home Assistant"
+          "enable_stream": "Usar stream do Home Assistant",
+          "enable_sound_detection": "Ativar detecção de limite de som"
         },
         "description": "Quase lá!\nSó mais algumas opções..."
       }
@@ -55,6 +56,7 @@
           "password": "Senha",
           "enable_motion_sensor": "Habilitar sensor de movimento",
           "enable_stream": "Usar stream do Home Assistant [requer reinicialização]",
+          "enable_sound_detection": "Ativar detecção de limite de som",
           "enable_time_sync": "Sincronizar Hora Automaticamente",
           "cloud_password": "Senha cloud (Opcional)"
         },

--- a/custom_components/tapo_control/translations/pt_BR.json
+++ b/custom_components/tapo_control/translations/pt_BR.json
@@ -27,7 +27,10 @@
           "enable_motion_sensor": "Habilitar sensor de movimento",
           "enable_time_sync": "Sincronizar Hora Automaticamente",
           "enable_stream": "Usar stream do Home Assistant",
-          "enable_sound_detection": "Ativar detecção de limite de som"
+          "enable_sound_detection": "Ativar detecção de limite de som",
+          "sound_detection_peak": "[Detecção de som] Pico em dB. 0 é muito alto e -100 é baixo.",
+          "sound_detection_duration": "[Detecção de som] Quanto tempo o ruído precisa estar acima do pico para acionar o estado.",
+          "sound_detection_reset": "[Detecção de som] O tempo para redefinir o estado depois que nenhum novo ruído ultrapassar o pico."
         },
         "description": "Quase lá!\nSó mais algumas opções..."
       }
@@ -40,7 +43,8 @@
       "connection_failed": "Conexão falhou",
       "invalid_auth_cloud": "Senha cloud inválida",
       "camera_requires_admin": "Sua câmera precisa de senha cloud para controle",
-      "already_configured": "Endereço IP já configurado"
+      "already_configured": "Endereço IP já configurado",
+      "incorrect_peak_value": "Valor de pico de detecção de som incorreto."
     },
     "abort": {
       "already_configured": "Endereço IP já configurado",
@@ -58,7 +62,10 @@
           "enable_stream": "Usar stream do Home Assistant [requer reinicialização]",
           "enable_sound_detection": "Ativar detecção de limite de som",
           "enable_time_sync": "Sincronizar Hora Automaticamente",
-          "cloud_password": "Senha cloud (Opcional)"
+          "cloud_password": "Senha cloud (Opcional)",
+          "sound_detection_peak": "[Detecção de som] Pico em dB. 0 é muito alto e -100 é baixo.",
+          "sound_detection_duration": "[Detecção de som] Quanto tempo o ruído precisa estar acima do pico para acionar o estado.",
+          "sound_detection_reset": "[Detecção de som] O tempo para redefinir o estado depois que nenhum novo ruído ultrapassar o pico."
         },
         "description": "Modificar configurações da sua Tapo câmera.\n\nUsar stream do Home Assistant:\nSim - Maior delay de reprodução, menor uso de CPU, permite controle de reprodução\nNão - delay de reprodução muito curto, maior uso de CPU, sem controle de reprodução"
       }
@@ -68,7 +75,8 @@
       "unknown": "Erro desconhecido",
       "connection_failed": "Conexão falhou",
       "invalid_auth_cloud": "Senha cloud inválida",
-      "camera_requires_admin": "Sua câmera precisa de senha cloud para controle"
+      "camera_requires_admin": "Sua câmera precisa de senha cloud para controle",
+      "incorrect_peak_value": "Valor de pico de detecção de som incorreto."
     }
   }
 }


### PR DESCRIPTION
# Version 3.3.0 🔊

## Description

This release adds a support for noise detection as requested in https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/71 .

You will need to enable this when adding the camera, or via options on existing cameras. When enabled, integration will analyse sound from camera stream in realtime and update a new attribute **noise_detected** to on, or off. This attribute is available only when noise detection is enabled and was initiated.

This expands possibilities of this camera, you could for example trigger an alarm based on noise or use the camera as baby monitor.

## Breaking changes

None.