### PR TITLE
bump onvif-zeep-async version to 1.2.0

### DIFF
--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -3,14 +3,18 @@
   "name": "Tapo: Cameras Control",
   "documentation": "https://github.com/JurajNyiri/HomeAssistant-Tapo-Control",
   "issue_tracker": "https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues",
-  "codeowners": ["@JurajNyiri"],
+  "codeowners": [
+    "@JurajNyiri"
+  ],
   "version": "3.4.1",
   "requirements": [
     "pytapo==1.2.1",
-    "onvif-zeep-async==1.0.0",
+    "onvif-zeep-async==1.2.0",
     "zeep[async]==4.0.0"
   ],
-  "dependencies": ["ffmpeg"],
+  "dependencies": [
+    "ffmpeg"
+  ],
   "config_flow": true,
   "homeassistant": "2021.2.0",
   "dhcp": [


### PR DESCRIPTION
Hi,

I had an issue with you integration since a recent update from homeassistant core (https://github.com/home-assistant/core/commit/61a7ce173c84bc8c3a9eede3ca36409dea9dc512). I am not sure if changing the version of onvif is sufficient, but it works on my end.

Thanks for this nice integration! :+1: 

Have a good day,

Christian-Nils