### PR TITLE
Fix device_state_attributes warnings

### DIFF
--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -189,7 +189,7 @@ class TapoCamEntity(Camera):
         return self.getUniqueID()
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return self._attributes
 
     @property


### PR DESCRIPTION
Fixes these kind of warnings beginning in 2021.12.0:
2021-12-13 21:02:03 WARNING (MainThread) [homeassistant.helpers.entity] Entity camera.outside_hd (<class 'custom_components.tapo_control.camera.TapoCamEntity'>) implements device_state_attributes. Please report it to the custom component author.