### PR TITLE
specify mac address in device_info.connections #170

### DIFF
--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -86,6 +86,9 @@ class TapoBinarySensor(BinarySensorEntity):
             "identifiers": {
                 (DOMAIN, slugify(f"{self._attributes['mac']}_tapo_control"))
             },
+            "connections": {
+                ("mac", self._attributes['mac'])
+            },
             "name": self._attributes["device_alias"],
             "manufacturer": "TP-Link",
             "model": self._attributes["device_model"],

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -203,6 +203,9 @@ class TapoCamEntity(Camera):
             "identifiers": {
                 (DOMAIN, slugify(f"{self._attributes['mac']}_tapo_control"))
             },
+            "connections": {
+                ("mac", self._attributes['mac'])
+            },
             "name": self._attributes["device_alias"],
             "manufacturer": "TP-Link",
             "model": self._attributes["device_model"],

--- a/custom_components/tapo_control/update.py
+++ b/custom_components/tapo_control/update.py
@@ -77,6 +77,9 @@ class TapoCamUpdate(UpdateEntity):
             "identifiers": {
                 (DOMAIN, slugify(f"{self._attributes['mac']}_tapo_control"))
             },
+            "connections": {
+                ("mac", self._attributes['mac'])
+            },
             "name": self._attributes["device_alias"],
             "manufacturer": "TP-Link",
             "model": self._attributes["device_model"],
@@ -138,4 +141,3 @@ class TapoCamUpdate(UpdateEntity):
             await self._coordinator.async_request_refresh()
         except Exception as e:
             LOGGER.error(e)
-


### PR DESCRIPTION
By specifying the mac address inside the device info, HASS core can merge the Device with devices from other integrations, that are also the same camera. This could be, i.e. your router.

This fixes #170.