### PR TITLE
binary_sensor and update entities are never unloaded #169

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -120,6 +120,9 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_unload(entry, "camera")
+    await hass.config_entries.async_forward_entry_unload(entry, "binary_sensor")
+    await hass.config_entries.async_forward_entry_unload(entry, "update")
+
     if hass.data[DOMAIN][entry.entry_id]["events"]:
         await hass.data[DOMAIN][entry.entry_id]["events"].async_stop()
     return True


### PR DESCRIPTION
All entities should be unloaded or otherwise HASS core will become confused once the integration is being reloaded. HASS will refuse to reload both the binary_sensor and the update entity, which then breaks the integration.

This fixes #169.