### PR TITLE
Add C320WS floodlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This custom component creates:
 - tapo_control.\* services to control a camera
 - 2 camera entities, one for HD and one for SD stream
 - 1 binary sensor for motion after the motion is detected for the first time
+- 1 light entity, if the camera supports a floodlight switch
 
 Use these services in following service calls.
 
@@ -248,6 +249,7 @@ Users reported full functionality with following Tapo Cameras:
 - C200
 - C210
 - C310
+- C320WS
 
 The integration _should_ work with any other Tapo Cameras.
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1,5 +1,7 @@
 import datetime
+
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_USERNAME,
@@ -10,7 +12,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import slugify
 from .const import (
+    BRAND,
     ENABLE_SOUND_DETECTION,
     CONF_CUSTOM_STREAM,
     LOGGER,
@@ -296,3 +300,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise ConfigEntryNotReady
 
     return True
+
+
+def build_device_info(attributes: dict) -> DeviceInfo:
+    return DeviceInfo(
+        identifiers={(DOMAIN, slugify(f"{attributes['mac']}_tapo_control"))},
+        connections={("mac", attributes["mac"])},
+        name=attributes["device_alias"],
+        manufacturer=BRAND,
+        model=attributes["device_model"],
+        sw_version=attributes["sw_version"],
+    )

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -277,7 +277,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if enableTimeSync:
                 await syncTime(hass, entry)
 
-        hass.config_entries.async_setup_platforms(entry, ["light"])
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, "light")
+        )
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, "camera")
         )

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -121,6 +121,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_unload(entry, "camera")
     await hass.config_entries.async_forward_entry_unload(entry, "binary_sensor")
+    await hass.config_entries.async_forward_entry_unload(entry, "light")
     await hass.config_entries.async_forward_entry_unload(entry, "update")
 
     if hass.data[DOMAIN][entry.entry_id]["events"]:
@@ -239,7 +240,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     ].async_schedule_update_ha_state(True)
 
         tapoCoordinator = DataUpdateCoordinator(
-            hass, LOGGER, name="Tapo resource status", update_method=async_update_data,
+            hass,
+            LOGGER,
+            name="Tapo resource status",
+            update_method=async_update_data,
         )
 
         camData = await getCamData(hass, tapoController)
@@ -271,6 +275,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if enableTimeSync:
                 await syncTime(hass, entry)
 
+        hass.config_entries.async_setup_platforms(entry, ["light"])
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, "camera")
         )

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1,7 +1,6 @@
 import datetime
 
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_USERNAME,
@@ -12,9 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util import slugify
+
 from .const import (
-    BRAND,
     ENABLE_SOUND_DETECTION,
     CONF_CUSTOM_STREAM,
     LOGGER,
@@ -300,14 +298,3 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise ConfigEntryNotReady
 
     return True
-
-
-def build_device_info(attributes: dict) -> DeviceInfo:
-    return DeviceInfo(
-        identifiers={(DOMAIN, slugify(f"{attributes['mac']}_tapo_control"))},
-        connections={("mac", attributes["mac"])},
-        name=attributes["device_alias"],
-        manufacturer=BRAND,
-        model=attributes["device_model"],
-        sw_version=attributes["sw_version"],
-    )

--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -1,7 +1,9 @@
 from typing import Optional
+from config.custom_components.tapo_control import build_device_info
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import callback
-from .const import DOMAIN, LOGGER
+from homeassistant.helpers.entity import DeviceInfo
+from .const import BRAND, DOMAIN, LOGGER
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.util import slugify
@@ -81,19 +83,8 @@ class TapoBinarySensor(BinarySensorEntity):
         return False
 
     @property
-    def device_info(self):
-        return {
-            "identifiers": {
-                (DOMAIN, slugify(f"{self._attributes['mac']}_tapo_control"))
-            },
-            "connections": {
-                ("mac", self._attributes['mac'])
-            },
-            "name": self._attributes["device_alias"],
-            "manufacturer": "TP-Link",
-            "model": self._attributes["device_model"],
-            "sw_version": self._attributes["sw_version"],
-        }
+    def device_info(self) -> DeviceInfo:
+        return build_device_info(self._attributes)
 
     @property
     def model(self):
@@ -101,7 +92,7 @@ class TapoBinarySensor(BinarySensorEntity):
 
     @property
     def brand(self):
-        return "TP-Link"
+        return BRAND
 
     async def async_added_to_hass(self):
         self.async_on_remove(self.events.async_add_listener(self.async_write_ha_state))

--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -6,8 +6,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from .const import BRAND, DOMAIN, LOGGER
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.util import slugify
-
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True

--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from config.custom_components.tapo_control import build_device_info
+from .utils import build_device_info
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -8,7 +8,6 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import callback
 from typing import Callable
 from homeassistant.helpers.entity import DeviceInfo
-from pytapo import Tapo
 from homeassistant.util import slugify
 from homeassistant.helpers import entity_platform
 from homeassistant.components.camera import (
@@ -136,7 +135,7 @@ class TapoCamEntity(Camera):
         self,
         hass: HomeAssistant,
         entry: dict,
-        tapoData: Tapo,
+        tapoData: dict,
         HDStream: boolean,
     ):
         super().__init__()

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -1,7 +1,7 @@
 import asyncio
 import urllib.parse
 import haffmpeg.sensor as ffmpeg_sensor
-from config.custom_components.tapo_control import build_device_info
+from .utils import build_device_info
 from homeassistant.helpers.config_validation import boolean
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_IP_ADDRESS, CONF_USERNAME, CONF_PASSWORD

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -1,11 +1,13 @@
 import asyncio
 import urllib.parse
 import haffmpeg.sensor as ffmpeg_sensor
+from config.custom_components.tapo_control import build_device_info
 from homeassistant.helpers.config_validation import boolean
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_IP_ADDRESS, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import callback
 from typing import Callable
+from homeassistant.helpers.entity import DeviceInfo
 from pytapo import Tapo
 from homeassistant.util import slugify
 from homeassistant.helpers import entity_platform
@@ -54,6 +56,7 @@ from .const import (
     PAN,
     PRESET,
     NAME,
+    BRAND,
 )
 
 
@@ -66,7 +69,9 @@ async def async_setup_entry(
 ):
     platform = entity_platform.current_platform.get()
     platform.async_register_entity_service(
-        SERVICE_SET_LED_MODE, SCHEMA_SERVICE_SET_LED_MODE, "set_led_mode",
+        SERVICE_SET_LED_MODE,
+        SCHEMA_SERVICE_SET_LED_MODE,
+        "set_led_mode",
     )
     platform.async_register_entity_service(
         SERVICE_SET_DAY_NIGHT_MODE,
@@ -74,13 +79,19 @@ async def async_setup_entry(
         "set_day_night_mode",
     )
     platform.async_register_entity_service(
-        SERVICE_SET_PRIVACY_MODE, SCHEMA_SERVICE_SET_PRIVACY_MODE, "set_privacy_mode",
+        SERVICE_SET_PRIVACY_MODE,
+        SCHEMA_SERVICE_SET_PRIVACY_MODE,
+        "set_privacy_mode",
     )
     platform.async_register_entity_service(
-        SERVICE_PTZ, SCHEMA_SERVICE_PTZ, "ptz",
+        SERVICE_PTZ,
+        SCHEMA_SERVICE_PTZ,
+        "ptz",
     )
     platform.async_register_entity_service(
-        SERVICE_SET_ALARM_MODE, SCHEMA_SERVICE_SET_ALARM_MODE, "set_alarm_mode",
+        SERVICE_SET_ALARM_MODE,
+        SCHEMA_SERVICE_SET_ALARM_MODE,
+        "set_alarm_mode",
     )
     platform.async_register_entity_service(
         SERVICE_SET_MOTION_DETECTION_MODE,
@@ -93,16 +104,24 @@ async def async_setup_entry(
         "set_auto_track_mode",
     )
     platform.async_register_entity_service(
-        SERVICE_REBOOT, SCHEMA_SERVICE_REBOOT, "reboot",
+        SERVICE_REBOOT,
+        SCHEMA_SERVICE_REBOOT,
+        "reboot",
     )
     platform.async_register_entity_service(
-        SERVICE_SAVE_PRESET, SCHEMA_SERVICE_SAVE_PRESET, "save_preset",
+        SERVICE_SAVE_PRESET,
+        SCHEMA_SERVICE_SAVE_PRESET,
+        "save_preset",
     )
     platform.async_register_entity_service(
-        SERVICE_DELETE_PRESET, SCHEMA_SERVICE_DELETE_PRESET, "delete_preset",
+        SERVICE_DELETE_PRESET,
+        SCHEMA_SERVICE_DELETE_PRESET,
+        "delete_preset",
     )
     platform.async_register_entity_service(
-        SERVICE_FORMAT, SCHEMA_SERVICE_FORMAT, "format",
+        SERVICE_FORMAT,
+        SCHEMA_SERVICE_FORMAT,
+        "format",
     )
 
     hass.data[DOMAIN][entry.entry_id]["entities"] = [
@@ -114,7 +133,11 @@ async def async_setup_entry(
 
 class TapoCamEntity(Camera):
     def __init__(
-        self, hass: HomeAssistant, entry: dict, tapoData: Tapo, HDStream: boolean,
+        self,
+        hass: HomeAssistant,
+        entry: dict,
+        tapoData: Tapo,
+        HDStream: boolean,
     ):
         super().__init__()
         self._controller = tapoData["controller"]
@@ -160,7 +183,8 @@ class TapoCamEntity(Camera):
     async def startNoiseDetection(self):
         self._hass.data[DOMAIN][self._entry.entry_id]["noiseSensorStarted"] = True
         await self._noiseSensor.open_sensor(
-            input_source=self.getStreamSource(), extra_cmd="-nostats",
+            input_source=self.getStreamSource(),
+            extra_cmd="-nostats",
         )
 
     async def async_added_to_hass(self) -> None:
@@ -198,19 +222,8 @@ class TapoCamEntity(Camera):
         return self._state
 
     @property
-    def device_info(self):
-        return {
-            "identifiers": {
-                (DOMAIN, slugify(f"{self._attributes['mac']}_tapo_control"))
-            },
-            "connections": {
-                ("mac", self._attributes['mac'])
-            },
-            "name": self._attributes["device_alias"],
-            "manufacturer": "TP-Link",
-            "model": self._attributes["device_model"],
-            "sw_version": self._attributes["sw_version"],
-        }
+    def device_info(self) -> DeviceInfo:
+        return build_device_info(self._attributes)
 
     @property
     def motion_detection_enabled(self):
@@ -218,7 +231,7 @@ class TapoCamEntity(Camera):
 
     @property
     def brand(self):
-        return "TP-Link"
+        return BRAND
 
     @property
     def model(self):
@@ -244,7 +257,8 @@ class TapoCamEntity(Camera):
         streaming_url = self.getStreamSource()
         stream = CameraMjpeg(self._ffmpeg.binary)
         await stream.open_camera(
-            streaming_url, extra_cmd=self._extra_arguments,
+            streaming_url,
+            extra_cmd=self._extra_arguments,
         )
         try:
             stream_reader = await stream.get_reader()
@@ -422,7 +436,9 @@ class TapoCamEntity(Camera):
             )
         else:
             await self.hass.async_add_executor_job(
-                self._controller.setMotionDetection, True, motion_detection_mode,
+                self._controller.setMotionDetection,
+                True,
+                motion_detection_mode,
             )
         await self._coordinator.async_request_refresh()
 

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from homeassistant.helpers import config_validation as cv
 
 DOMAIN = "tapo_control"
+BRAND = "TP-Link"
 ALARM_MODE = "alarm_mode"
 PRESET = "preset"
 LIGHT = "light"

--- a/custom_components/tapo_control/light.py
+++ b/custom_components/tapo_control/light.py
@@ -1,4 +1,4 @@
-from config.custom_components.tapo_control import build_device_info
+from .utils import build_device_info
 from homeassistant.components.light import LightEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/tapo_control/light.py
+++ b/custom_components/tapo_control/light.py
@@ -1,0 +1,93 @@
+from homeassistant.components.light import LightEntity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from .const import DOMAIN, LOGGER
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.util import slugify
+from pytapo import Tapo
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    return True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    LOGGER.debug("Setting up light for floodlight")
+    name = hass.data[DOMAIN][config_entry.entry_id]["name"]
+    controller: Tapo = hass.data[DOMAIN][config_entry.entry_id]["controller"]
+    cam_data = hass.data[DOMAIN][config_entry.entry_id]["camData"]
+
+    try:
+        await hass.async_add_executor_job(controller.getForceWhitelampState)
+    except Exception:
+        LOGGER.info("Camera does not support floodlight")
+        return
+
+    LOGGER.debug("Creating light entity")
+    light = TapoFloodlight(name, controller, hass, cam_data)
+    async_add_entities([light])
+
+
+class TapoFloodlight(LightEntity):
+    def __init__(self, name, controller: Tapo, hass: HomeAssistant, cam_data):
+        LOGGER.debug("TapoFloodlight - init - start")
+        self._name = name
+        self._controller = controller
+        self._attributes = cam_data["basic_info"]
+        self._is_on = False
+        self._hass = hass
+        LightEntity.__init__(self)
+        LOGGER.debug("TapoFloodlight - init - end")
+
+    @property
+    def is_on(self) -> bool:
+        return self._is_on
+
+    @property
+    def name(self) -> str:
+        return "{} - Floodlight".format(self._name)
+
+    async def async_turn_on(self) -> None:
+        await self._hass.async_add_executor_job(
+            self._controller.setForceWhitelampState,
+            True,
+        )
+
+    async def async_turn_off(self) -> None:
+        await self._hass.async_add_executor_job(
+            self._controller.setForceWhitelampState,
+            False,
+        )
+
+    async def async_update(self) -> None:
+        self._is_on = await self._hass.async_add_executor_job(
+            self._controller.getForceWhitelampState
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, slugify(f"{self._attributes['mac']}_tapo_control"))},
+            connections={("mac", self._attributes["mac"])},
+            name=self._attributes["device_alias"],
+            manufacturer="TP-Link",
+            model=self._attributes["device_model"],
+            sw_version=self._attributes["sw_version"],
+        )
+
+    @property
+    def unique_id(self) -> str:
+        return "{}-floodlight".format(self._name).lower()
+
+    @property
+    def model(self):
+        return self._attributes["device_model"]
+
+    @property
+    def brand(self):
+        return "TP-Link"

--- a/custom_components/tapo_control/light.py
+++ b/custom_components/tapo_control/light.py
@@ -34,11 +34,11 @@ async def async_setup_entry(
 
 
 class TapoFloodlight(LightEntity):
-    def __init__(self, name, controller: Tapo, hass: HomeAssistant, attribtutes: dict):
+    def __init__(self, name, controller: Tapo, hass: HomeAssistant, attributes: dict):
         LOGGER.debug("TapoFloodlight - init - start")
         self._name = name
         self._controller = controller
-        self._attributes = attribtutes
+        self._attributes = attributes
         self._is_on = False
         self._hass = hass
         LightEntity.__init__(self)

--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues",
   "codeowners": ["@JurajNyiri"],
   "version": "3.5.0",
-  "requirements": ["pytapo==2.1", "onvif-zeep-async==1.2.0"],
+  "requirements": ["pytapo==2.2", "onvif-zeep-async==1.2.0"],
   "dependencies": ["ffmpeg"],
   "config_flow": true,
   "homeassistant": "2022.4.0",
@@ -1761,6 +1761,10 @@
     {
       "hostname": "c310_*",
       "macaddress": "FCD733*"
+    },
+    {
+      "hostname": "c320ws_*",
+      "macaddress": "B4B024*"
     },
     {
       "hostname": "tc70_*",

--- a/custom_components/tapo_control/update.py
+++ b/custom_components/tapo_control/update.py
@@ -5,7 +5,6 @@ from typing import Callable
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.helpers.entity import DeviceInfo
 from .const import DOMAIN, LOGGER
-from homeassistant.util import slugify
 
 
 async def async_setup_entry(

--- a/custom_components/tapo_control/update.py
+++ b/custom_components/tapo_control/update.py
@@ -1,10 +1,11 @@
+from config.custom_components.tapo_control import build_device_info
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from typing import Callable
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
+from homeassistant.helpers.entity import DeviceInfo
 from .const import DOMAIN, LOGGER
 from homeassistant.util import slugify
-from pytapo import Tapo
 
 
 async def async_setup_entry(
@@ -18,7 +19,10 @@ async def async_setup_entry(
 
 class TapoCamUpdate(UpdateEntity):
     def __init__(
-        self, hass: HomeAssistant, entry: dict, tapoData: Tapo,
+        self,
+        hass: HomeAssistant,
+        entry: dict,
+        tapoData,
     ):
         super().__init__()
         self._controller = tapoData["controller"]
@@ -72,19 +76,8 @@ class TapoCamUpdate(UpdateEntity):
         return "Camera - " + self._attributes["device_alias"]
 
     @property
-    def device_info(self):
-        return {
-            "identifiers": {
-                (DOMAIN, slugify(f"{self._attributes['mac']}_tapo_control"))
-            },
-            "connections": {
-                ("mac", self._attributes['mac'])
-            },
-            "name": self._attributes["device_alias"],
-            "manufacturer": "TP-Link",
-            "model": self._attributes["device_model"],
-            "sw_version": self._attributes["sw_version"],
-        }
+    def device_info(self) -> DeviceInfo:
+        return build_device_info(self._attributes)
 
     @property
     def in_progress(self) -> bool:
@@ -131,7 +124,9 @@ class TapoCamUpdate(UpdateEntity):
         return "Tapo Camera: {0}".format(self._attributes["device_alias"])
 
     async def async_install(
-        self, version, backup,
+        self,
+        version,
+        backup,
     ):
         try:
             await self.hass.async_add_executor_job(

--- a/custom_components/tapo_control/update.py
+++ b/custom_components/tapo_control/update.py
@@ -1,4 +1,4 @@
-from config.custom_components.tapo_control import build_device_info
+from .utils import build_device_info
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from typing import Callable

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -62,10 +62,14 @@ async def isRtspStreamWorking(hass, host, username, password, full_url=""):
         ),
     )
     image = await asyncio.shield(
-        ffmpeg.get_image(streaming_url, output_format=IMAGE_JPEG,)
+        ffmpeg.get_image(
+            streaming_url,
+            output_format=IMAGE_JPEG,
+        )
     )
     LOGGER.debug(
-        "[isRtspStreamWorking][%s] Image data received.", host,
+        "[isRtspStreamWorking][%s] Image data received.",
+        host,
     )
     return not image == b""
 

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -8,6 +8,7 @@ import time
 from onvif import ONVIFCamera
 from pytapo import Tapo
 from .const import (
+    BRAND,
     ENABLE_MOTION_SENSOR,
     DOMAIN,
     LOGGER,
@@ -17,8 +18,9 @@ from .const import (
 from homeassistant.const import CONF_IP_ADDRESS, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.components.onvif.event import EventManager
 from homeassistant.components.ffmpeg import DATA_FFMPEG
+from homeassistant.helpers.entity import DeviceInfo
 from haffmpeg.tools import IMAGE_JPEG, ImageFrame
-
+from homeassistant.util import slugify
 
 def registerController(host, username, password):
     return Tapo(host, username, password)
@@ -300,3 +302,14 @@ async def setupEvents(hass, entry):
             return True
         else:
             return False
+
+
+def build_device_info(attributes: dict) -> DeviceInfo:
+    return DeviceInfo(
+        identifiers={(DOMAIN, slugify(f"{attributes['mac']}_tapo_control"))},
+        connections={("mac", attributes["mac"])},
+        name=attributes["device_alias"],
+        manufacturer=BRAND,
+        model=attributes["device_model"],
+        sw_version=attributes["sw_version"],
+    )


### PR DESCRIPTION
# Context
Draft support for the C320WS floodlight.

# Changes
- Adds DHCP mac address and hostname matcher
- Adds new light entity for the C320WS floodlight. Should only be added for Tapo cameras that support a floodlight switch.
- Slight refactor to reduce duplication DeviceInfo generation
- Also includes linting as applied by Home Assistant dev container
- Re-typed `tapoData` as a `dict`, as it is not a `Tapo` instance.


https://user-images.githubusercontent.com/1448441/167851478-5762873e-d48b-4c12-b65c-dc3f6131ca45.mp4

# Caveats
- This is my first publicly available Home Assistant integration work, and may be missing important things.
- Concerns about unloading. When unloading, the integration tries to unload the binary sensor, camera(s), update, and light, even if they were never added. This issue was present before, but the light follows the same pattern and will need to be fixed.
- Concerns about unique device IDs. The camera component uses 
   ```
   slugify(f"{self._attributes['mac']}_{streamType}_tapo_control")
    ```
    to generate a unique ID, but the previous (and now refactored) `device_info` accessor doesn't use the streamType, instead just using the generic
   ```
    slugify(f"{attributes['mac']}_tapo_control"))}
    ```
    Not sure if this a problem.
- I have been testing this locally with multiple Home Assistant instances, but will need advice on common scenarios to test.

I'm open to feedback and happy to take time to test other scenarios!