### PR TITLE
fix(sensors): remove dash from sensor names

### DIFF
--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -62,7 +62,7 @@ class TapoBinarySensor(BinarySensorEntity):
 
     @property
     def name(self) -> str:
-        return f"{self._name} - Motion"
+        return f"{self._name} Motion"
 
     @property
     def device_class(self) -> Optional[str]:

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -196,7 +196,7 @@ class TapoCamEntity(Camera):
 
     @property
     def name(self) -> str:
-        return self.getName().replace(' - ', ' ')
+        return self.getName()
 
     @property
     def unique_id(self) -> str:
@@ -301,9 +301,9 @@ class TapoCamEntity(Camera):
     def getName(self):
         name = self._attributes["device_alias"]
         if self._hdstream:
-            name += " - HD"
+            name += " HD"
         else:
-            name += " - SD"
+            name += " SD"
         return name
 
     def getUniqueID(self):

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -196,7 +196,7 @@ class TapoCamEntity(Camera):
 
     @property
     def name(self) -> str:
-        return self.getName()
+        return self.getName().replace(' - ', ' ')
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
The integration provides sensors names which are prefixed with the camera name separated with a dash (`-`): `Flur -HD`, `Flur - Motion`

Within HA the camera name is trimmed again from the sensor name and it looks a bit odd like this:

<img width="896" alt="Bildschirmfoto 2022-10-17 um 14 34 05" src="https://user-images.githubusercontent.com/9592452/196179046-938d79cc-e20a-404c-b04c-bf95bccb2522.png">


Therefore I suggest to simply remove the `-`.
