### PR TITLE
feat(config): list privacy mode under general controls instead of configuration

### DIFF
--- a/custom_components/tapo_control/switch.py
+++ b/custom_components/tapo_control/switch.py
@@ -124,6 +124,10 @@ class TapoPrivacySwitch(TapoSwitchEntity):
             return "mdi:eye-off-outline"
         else:
             return "mdi:eye-outline"
+        
+    @property
+    def entity_category(self):
+        return None
 
 
 class TapoIndicatorLedSwitch(TapoSwitchEntity):


### PR DESCRIPTION
I consider the "privacy mode" a general action and not a configuration setting. 

<img width="335" alt="Bildschirmfoto 2022-10-20 um 10 10 07" src="https://user-images.githubusercontent.com/9592452/196893217-773b5188-6454-410d-986f-363c8e2e8eb5.png">
