### PR TITLE
feat(entity): change from clock icon to alarm-light icon

### DIFF
--- a/custom_components/tapo_control/button.py
+++ b/custom_components/tapo_control/button.py
@@ -76,7 +76,7 @@ class TapoSyncTimeButton(TapoButtonEntity):
 
 class TapoStartManualAlarmButton(TapoButtonEntity):
     def __init__(self, entry: dict, hass: HomeAssistant, config_entry):
-        TapoButtonEntity.__init__(self, "Manual Alarm Start", entry, hass, "mdi:alarm")
+        TapoButtonEntity.__init__(self, "Manual Alarm Start", entry, hass, "mdi:alarm-light-outline")
 
     async def async_press(self) -> None:
         await self._hass.async_add_executor_job(self._controller.startManualAlarm)
@@ -85,7 +85,7 @@ class TapoStartManualAlarmButton(TapoButtonEntity):
 class TapoStopManualAlarmButton(TapoButtonEntity):
     def __init__(self, entry: dict, hass: HomeAssistant, config_entry):
         TapoButtonEntity.__init__(
-            self, "Manual Alarm Stop", entry, hass, "mdi:alarm-off",
+            self, "Manual Alarm Stop", entry, hass, "mdi:alarm-light-off-outline",
         )
 
     async def async_press(self) -> None:

--- a/custom_components/tapo_control/select.py
+++ b/custom_components/tapo_control/select.py
@@ -108,7 +108,7 @@ class TapoAutomaticAlarmModeSelect(TapoSelectEntity):
             entry,
             hass,
             config_entry,
-            "mdi:alarm-check",
+            "mdi:alarm-light-outline",
             "alarm",
         )
 


### PR DESCRIPTION
Changing the clock-like icon to an alarm-light for the manual alarm switches and the alarm select entity.

<img width="337" alt="Bildschirmfoto 2022-10-21 um 09 17 43" src="https://user-images.githubusercontent.com/9592452/197137992-307de0f8-2a63-416d-b948-000414c55bae.png">
