### PR TITLE
Allows use in the Home Assistant beta version

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
     "name": "Tapo: Cameras Control",
-    "homeassistant": "2023.5.0"
+    "homeassistant": "2023.5.0b0"
 }


### PR DESCRIPTION
Change `hacs.json` file to allow installation via HACS if running beta version of Home Assistant ([see example in HACS documentation here](https://hacs.xyz/docs/publish/start#hacsjson)).
![image](https://user-images.githubusercontent.com/31328123/234723139-15435780-547c-4e31-8f9a-584c7be96ee3.png)

