### PR TITLE
5.3.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
-    "python.formatting.provider": "black"
+    "python.formatting.provider": "none",
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This custom component creates:
 - Switch entities for auto track, Flip setting, LED Indicator, Lens Distortion Correction and Privacy mode
 - Select entities for Automatic Alarm, Light Frequency, Motion Detection, Night Vision and Move to Preset
 - Number entity for Movement Angle
+- Media Source for browsing and playing recordings stored on camera
+- Sensor entity that reports monitor media sync status
 - And finally 2 tapo_control.\* services to control a camera
 
 Use these services in following service calls.
@@ -72,6 +74,20 @@ Integration is capable of analysing sound from camera microphone and expose nois
 You need to enable this feature in integration options by checking "Enable sound threshold detection". After enabling it, you can also set any other options starting with [Sound Detection]. You will need to restart Home Asssistant after doing any changes.
 
 For more information and troubleshooting see [Home Assistant ffmpeg documentation](https://www.home-assistant.io/integrations/ffmpeg_noise/) on which this feature is based on.
+
+## Media Sync
+
+Integration is capable of synchronizing recordings for fast playback.
+
+Synchronization is turned off by default, you can browse media stored on camera and request it to be played. However, downloading is rather slow, so it is a good idea to enable media synchronization in background. That way, you will be able to play any synchronized media from camera instantly.
+
+You can enable this setting by navigating to Home Assistant Settings -> Devices and clicking on Configure button next to the Tapo device you wish to turn media synchronization on for.
+
+You need to also define the number of hours to synchronize. Unless it is specified, synchronization does not run.
+
+Finally, you are able to set the storage path where the synchronized recordings will be stored (defaults to /config/.storage/tapo_control).
+
+**Notice:**: Recordings are deleted after the number of hours you have chosen to synchronize passes, once both the actual recording time and the file modified time is older than the number of hours set.
 
 ## Troubleshooting | FAQ
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -387,6 +387,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     get_state,
                     timedelta(seconds=1),
                 )
+            elif hass.data[DOMAIN][entry.entry_id]["initialMediaScanRunning"] is False:
+                hass.data[DOMAIN][entry.entry_id]["initialMediaScanRunning"] = True
+                hass.async_create_background_task(
+                    findMedia(hass, entry.entry_id), "findMedia"
+                )
 
         tapoCoordinator = DataUpdateCoordinator(
             hass,
@@ -428,6 +433,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "downloadedStreams": {},
             "downloadProgress": False,
             "initialMediaScanDone": False,
+            "initialMediaScanRunning": False,
             "timezoneOffset": cameraTS - currentTS,
         }
 
@@ -550,8 +556,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                 except Exception as err:
                                     LOGGER.error(err)
                 hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] = False
-
-        hass.async_create_background_task(findMedia(hass, entry.entry_id), "findMedia")
 
         async def unsubscribe(event):
             if hass.data[DOMAIN][entry.entry_id]["events"]:

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -442,6 +442,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN][entry.entry_id] = {
             "runningMediaSync": False,
             "controller": tapoController,
+            "entry": entry,
             "usingCloudPassword": cloud_password != "",
             "allControllers": [tapoController],
             "update_listener": entry.add_update_listener(update_listener),

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -582,8 +582,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 and hass.data[DOMAIN][entry.entry_id]["isDownloadingStream"]
                 is False  # prevent breaking user manual upload
             ):
+                hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] = True
                 try:
-                    hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] = True
                     tapoController: Tapo = hass.data[DOMAIN][entry.entry_id][
                         "controller"
                     ]

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import os
 import shutil
 import asyncio
@@ -235,6 +236,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         async def async_update_data():
             LOGGER.warn("async_update_data - entry")
+            tapoController = hass.data[DOMAIN][entry.entry_id]["controller"]
             host = entry.data.get(CONF_IP_ADDRESS)
             username = entry.data.get(CONF_USERNAME)
             password = entry.data.get(CONF_PASSWORD)
@@ -442,6 +444,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "name": camData["basic_info"]["device_alias"],
             "childDevices": [],
             "isChild": False,
+            "uuid": hashlib.md5(
+                (
+                    str(host) + str(username) + str(password) + str(cloud_password)
+                ).encode()
+            ).hexdigest(),
             "isParent": False,
             "isDownloadingStream": False,
             "downloadedStreams": {},

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -35,6 +35,7 @@ from .const import (
     ENABLE_STREAM,
     ENABLE_TIME_SYNC,
     MEDIA_CLEANUP_PERIOD,
+    MEDIA_SYNC_COLD_STORAGE_PATH,
     MEDIA_SYNC_HOURS,
     RTSP_TRANS_PROTOCOLS,
     SOUND_DETECTION_DURATION,
@@ -169,6 +170,14 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         config_entry.data = {**new}
 
         config_entry.version = 12
+
+    if config_entry.version == 12:
+        new = {**config_entry.data}
+        new[MEDIA_SYNC_COLD_STORAGE_PATH] = ""
+
+        config_entry.data = {**new}
+
+        config_entry.version = 13
 
     LOGGER.warn("Migration to version %s successful", config_entry.version)
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -456,11 +456,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             ).hexdigest(),
             "isParent": False,
             "isDownloadingStream": False,
-            "downloadedStreams": {},
+            "downloadedStreams": {},  # keeps track of all videos downloaded
             "downloadProgress": False,
             "initialMediaScanDone": False,
             "initialMediaScanRunning": False,
-            "mediaScanResult": {},
+            "mediaScanResult": {},  # keeps track of all videos currently on camera
             "timezoneOffset": cameraTS - currentTS,
         }
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -394,10 +394,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             ):
                 mediaCleanup(hass, entry.entry_id)
 
-            if (
-                hass.data[DOMAIN][entry.entry_id]["initialMediaScanDone"] is True
-                and enableMediaSync
-            ):
+            if hass.data[DOMAIN][entry.entry_id]["initialMediaScanDone"] is True:
                 async_track_time_interval(
                     hass,
                     mediaSync,
@@ -543,10 +540,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         async def mediaSync(time=None):
             enableMediaSync = entry.data.get(ENABLE_MEDIA_SYNC)
             if (
-                entry.entry_id in hass.data[DOMAIN]
+                enableMediaSync
+                and entry.entry_id in hass.data[DOMAIN]
                 and "controller" in hass.data[DOMAIN][entry.entry_id]
                 and hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] is False
-                and enableMediaSync
             ):
                 hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] = True
                 tapoController: Tapo = hass.data[DOMAIN][entry.entry_id]["controller"]

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -412,7 +412,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "isChild": False,
             "isParent": False,
             "isDownloadingStream": False,
-            "downloadedStreams": [],
+            "downloadedStreams": {},
             "initialMediaScanDone": False,
             "timezoneOffset": cameraTS - currentTS,
         }

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -410,6 +410,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "isChild": False,
             "isParent": False,
             "isDownloadingStream": False,
+            "downloadedStreams": [],
             "timezoneOffset": cameraTS - currentTS,
         }
 
@@ -516,6 +517,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                         LOGGER.warn(recordingsForDay)
                         for recording in recordingsForDay:
                             for recordingKey in recording:
+                                LOGGER.warn(recordingKey)
                                 hass.data[DOMAIN][entry.entry_id][
                                     "isDownloadingStream"
                                 ] = True
@@ -536,8 +538,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                     LOGGER.warn(err)
                                 except Exception as err:
                                     LOGGER.error(err)
-            else:
-                LOGGER.warn("Sync currently running")
 
         LOGGER.warn("Media init")
         async_track_time_interval(

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -538,9 +538,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                             tapoController.getRecordings, searchResult[key]["date"]
                         )
                         LOGGER.warn(recordingsForDay)
+                        recordingCount = 0
                         for recording in recordingsForDay:
                             for recordingKey in recording:
-                                LOGGER.warn(recordingKey)
+                                recordingCount += 1
                                 try:
                                     url = await getRecording(
                                         hass,
@@ -549,6 +550,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                         searchResult[key]["date"],
                                         recording[recordingKey]["startTime"],
                                         recording[recordingKey]["endTime"],
+                                        recordingCount,
                                     )
                                     LOGGER.warn(url)
                                 except Unresolvable as err:

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -372,7 +372,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if (
                 ts - hass.data[DOMAIN][entry.entry_id]["lastMediaCleanup"]
                 > MEDIA_CLEANUP_PERIOD
-            )
+            ):
                 mediaCleanup(hass, entry.entry_id)
 
         tapoCoordinator = DataUpdateCoordinator(

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -223,6 +223,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             password = entry.data.get(CONF_PASSWORD)
             motionSensor = entry.data.get(ENABLE_MOTION_SENSOR)
             enableTimeSync = entry.data.get(ENABLE_TIME_SYNC)
+            ts = datetime.datetime.utcnow().timestamp()
 
             # motion detection retries
             if motionSensor or enableTimeSync:
@@ -273,7 +274,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                         "Not updating motion sensor because device is child or parent."
                     )
 
-                ts = datetime.datetime.utcnow().timestamp()
                 if (
                     hass.data[DOMAIN][entry.entry_id]["onvifManagement"]
                     and enableTimeSync
@@ -283,11 +283,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                         > TIME_SYNC_PERIOD
                     ):
                         await syncTime(hass, entry.entry_id)
-                if (
-                    ts - hass.data[DOMAIN][entry.entry_id]["lastMediaCleanup"]
-                    > MEDIA_CLEANUP_PERIOD
-                ):
-                    mediaCleanup(hass, entry.entry_id)
                 ts = datetime.datetime.utcnow().timestamp()
                 if (
                     ts - hass.data[DOMAIN][entry.entry_id]["lastFirmwareCheck"]
@@ -373,6 +368,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     hass.data[DOMAIN][entry.entry_id][
                         "updateEntity"
                     ].async_schedule_update_ha_state(True)
+
+            if (
+                ts - hass.data[DOMAIN][entry.entry_id]["lastMediaCleanup"]
+                > MEDIA_CLEANUP_PERIOD
+            )
+                mediaCleanup(hass, entry.entry_id)
 
         tapoCoordinator = DataUpdateCoordinator(
             hass,

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -179,7 +179,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 
         config_entry.version = 13
 
-    LOGGER.warn("Migration to version %s successful", config_entry.version)
+    LOGGER.info("Migration to version %s successful", config_entry.version)
 
     return True
 
@@ -254,7 +254,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             return allEntities
 
         async def async_update_data():
-            LOGGER.warn("async_update_data - entry")
+            LOGGER.debug("async_update_data - entry")
             tapoController = hass.data[DOMAIN][entry.entry_id]["controller"]
             host = entry.data.get(CONF_IP_ADDRESS)
             username = entry.data.get(CONF_USERNAME)
@@ -565,21 +565,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
         async def mediaSync(time=None):
-            LOGGER.warn("mediaSync")
+            LOGGER.debug("mediaSync")
             enableMediaSync = entry.data.get(ENABLE_MEDIA_SYNC)
             mediaSyncHours = entry.data.get(MEDIA_SYNC_HOURS)
 
-            LOGGER.warn(
-                str(enableMediaSync)
-                + ","
-                + str(entry.entry_id in hass.data[DOMAIN])
-                + ","
-                + str("controller" in hass.data[DOMAIN][entry.entry_id])
-                + ","
-                + str(hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] is False)
-                + ","
-                + str(hass.data[DOMAIN][entry.entry_id]["isDownloadingStream"] is False)
-            )
             if mediaSyncHours == "":
                 mediaSyncTime = False
             else:
@@ -597,11 +586,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     tapoController: Tapo = hass.data[DOMAIN][entry.entry_id][
                         "controller"
                     ]
-                    LOGGER.warn("getRecordingsList -1")
+                    LOGGER.debug("getRecordingsList -1")
                     recordingsList = await hass.async_add_executor_job(
                         tapoController.getRecordingsList
                     )
-                    LOGGER.warn("getRecordingsList -2")
+                    LOGGER.debug("getRecordingsList -2")
 
                     ts = datetime.datetime.utcnow().timestamp()
                     for searchResult in recordingsList:
@@ -617,11 +606,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                     )
                                 )
                             ):
-                                LOGGER.warn("getRecordings -1")
+                                LOGGER.debug("getRecordings -1")
                                 recordingsForDay = await getRecordings(
                                     hass, entry.entry_id, searchResult[key]["date"]
                                 )
-                                LOGGER.warn("getRecordings -2")
+                                LOGGER.debug("getRecordings -2")
                                 totalRecordingsToDownload = 0
                                 for recording in recordingsForDay:
                                     for recordingKey in recording:
@@ -637,7 +626,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                         ):
                                             recordingCount += 1
                                             try:
-                                                LOGGER.warn("getRecording -1")
+                                                LOGGER.debug("getRecording -1")
                                                 await getRecording(
                                                     hass,
                                                     tapoController,
@@ -650,14 +639,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                                     recordingCount,
                                                     totalRecordingsToDownload,
                                                 )
-                                                LOGGER.warn("getRecording -2")
+                                                LOGGER.debug("getRecording -2")
                                             except Unresolvable as err:
                                                 LOGGER.warn(err)
                                             except Exception as err:
                                                 LOGGER.error(err)
                 except Exception as err:
                     LOGGER.error(err)
-                LOGGER.warn("runningMediaSync -false")
+                LOGGER.debug("runningMediaSync -false")
                 hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] = False
 
         async def unsubscribe(event):

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -434,6 +434,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "downloadProgress": False,
             "initialMediaScanDone": False,
             "initialMediaScanRunning": False,
+            "mediaScanResult": {},
             "timezoneOffset": cameraTS - currentTS,
         }
 
@@ -525,19 +526,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 and hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] is False
             ):
                 hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] = True
-                LOGGER.warn("testing")
                 tapoController: Tapo = hass.data[DOMAIN][entry.entry_id]["controller"]
                 recordingsList = await hass.async_add_executor_job(
                     tapoController.getRecordingsList
                 )
-                LOGGER.warn(recordingsList)
 
                 for searchResult in recordingsList:
                     for key in searchResult:
                         recordingsForDay = await hass.async_add_executor_job(
                             tapoController.getRecordings, searchResult[key]["date"]
                         )
-                        LOGGER.warn(recordingsForDay)
                         recordingCount = 0
                         for recording in recordingsForDay:
                             for recordingKey in recording:
@@ -552,7 +550,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                         recording[recordingKey]["endTime"],
                                         recordingCount,
                                     )
-                                    LOGGER.warn(url)
                                 except Unresolvable as err:
                                     LOGGER.warn(err)
                                 except Exception as err:

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -444,6 +444,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "lastMediaCleanup": 0,
             "lastFirmwareCheck": 0,
             "latestFirmwareVersion": False,
+            "mediaSyncColdDir": False,
+            "mediaSyncHotDir": False,
             "motionSensorCreated": False,
             "eventsDevice": False,
             "onvifManagement": False,

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt
+from homeassistant.components.media_source.error import Unresolvable
 
 from .const import (
     CONF_RTSP_TRANSPORT,
@@ -518,18 +519,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                 hass.data[DOMAIN][entry.entry_id][
                                     "isDownloadingStream"
                                 ] = True
-                                url = await getRecording(
-                                    hass,
-                                    tapoController,
-                                    entry.entry_id,
-                                    searchResult[key]["date"],
-                                    recording[recordingKey]["startTime"],
-                                    recording[recordingKey]["endTime"],
-                                )
-                                hass.data[DOMAIN][entry.entry_id][
-                                    "isDownloadingStream"
-                                ] = False
-                                LOGGER.warn(url)
+                                try:
+                                    url = await getRecording(
+                                        hass,
+                                        tapoController,
+                                        entry.entry_id,
+                                        searchResult[key]["date"],
+                                        recording[recordingKey]["startTime"],
+                                        recording[recordingKey]["endTime"],
+                                    )
+                                    hass.data[DOMAIN][entry.entry_id][
+                                        "isDownloadingStream"
+                                    ] = False
+                                    LOGGER.warn(url)
+                                except Unresolvable as err:
+                                    LOGGER.warn(err)
+                                except Exception as err:
+                                    LOGGER.error(err)
             else:
                 LOGGER.warn("Sync currently running")
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -55,6 +55,7 @@ from .utils import (
     syncTime,
     getLatestFirmwareVersion,
     findMedia,
+    getRecordings,
 )
 from pytapo import Tapo
 
@@ -533,8 +534,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
                 for searchResult in recordingsList:
                     for key in searchResult:
-                        recordingsForDay = await hass.async_add_executor_job(
-                            tapoController.getRecordings, searchResult[key]["date"]
+                        recordingsForDay = await getRecordings(
+                            hass, entry.entry_id, searchResult[key]["date"]
                         )
                         recordingCount = 0
                         for recording in recordingsForDay:

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1,12 +1,5 @@
 import datetime
 import hashlib
-import os
-import shutil
-import asyncio
-from threading import Thread
-import time
-from concurrent.futures import ProcessPoolExecutor
-import threading
 
 from homeassistant.core import HomeAssistant
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
@@ -226,7 +219,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     motionSensor = entry.data.get(ENABLE_MOTION_SENSOR)
     cloud_password = entry.data.get(CLOUD_PASSWORD)
     enableTimeSync = entry.data.get(ENABLE_TIME_SYNC)
-    enableMediaSync = entry.data.get(ENABLE_MEDIA_SYNC)
 
     if isUsingHTTPS(hass):
         LOGGER.warn(

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -24,6 +24,7 @@ from .const import (
     LOGGER,
     CLOUD_PASSWORD,
     ENABLE_TIME_SYNC,
+    MEDIA_SYNC_COLD_STORAGE_PATH,
     MEDIA_SYNC_HOURS,
     SOUND_DETECTION_DURATION,
     SOUND_DETECTION_PEAK,
@@ -38,7 +39,7 @@ from .const import (
 class FlowHandler(ConfigFlow):
     """Handle a config flow."""
 
-    VERSION = 12
+    VERSION = 13
 
     @staticmethod
     def async_get_options_flow(config_entry):
@@ -595,6 +596,9 @@ class TapoOptionsFlowHandler(OptionsFlow):
         errors = {}
         enable_media_sync = self.config_entry.data[ENABLE_MEDIA_SYNC]
         media_sync_hours = self.config_entry.data[MEDIA_SYNC_HOURS]
+        media_sync_cold_storage_path = self.config_entry.data[
+            MEDIA_SYNC_COLD_STORAGE_PATH
+        ]
         ip_address = self.config_entry.data[CONF_IP_ADDRESS]
 
         allConfigData = {**self.config_entry.data}
@@ -610,8 +614,18 @@ class TapoOptionsFlowHandler(OptionsFlow):
                 else:
                     media_sync_hours = ""
 
+                if MEDIA_SYNC_COLD_STORAGE_PATH in user_input:
+                    media_sync_cold_storage_path = user_input[
+                        MEDIA_SYNC_COLD_STORAGE_PATH
+                    ]
+                else:
+                    media_sync_cold_storage_path = ""
+
                 allConfigData[ENABLE_MEDIA_SYNC] = enable_media_sync
                 allConfigData[MEDIA_SYNC_HOURS] = media_sync_hours
+                allConfigData[
+                    MEDIA_SYNC_COLD_STORAGE_PATH
+                ] = media_sync_cold_storage_path
                 # todo also initial setup to add the default values!
                 self.hass.config_entries.async_update_entry(
                     self.config_entry,
@@ -647,6 +661,10 @@ class TapoOptionsFlowHandler(OptionsFlow):
                         MEDIA_SYNC_HOURS,
                         description={"suggested_value": media_sync_hours},
                     ): int,
+                    vol.Optional(
+                        MEDIA_SYNC_COLD_STORAGE_PATH,
+                        description={"suggested_value": media_sync_cold_storage_path},
+                    ): str,
                 }
             ),
             errors=errors,

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -24,6 +24,7 @@ from .const import (
     LOGGER,
     CLOUD_PASSWORD,
     ENABLE_TIME_SYNC,
+    MEDIA_SYNC_HOURS,
     SOUND_DETECTION_DURATION,
     SOUND_DETECTION_PEAK,
     SOUND_DETECTION_RESET,
@@ -37,7 +38,7 @@ from .const import (
 class FlowHandler(ConfigFlow):
     """Handle a config flow."""
 
-    VERSION = 11
+    VERSION = 12
 
     @staticmethod
     def async_get_options_flow(config_entry):
@@ -593,6 +594,7 @@ class TapoOptionsFlowHandler(OptionsFlow):
         )
         errors = {}
         enable_media_sync = self.config_entry.data[ENABLE_MEDIA_SYNC]
+        media_sync_hours = self.config_entry.data[MEDIA_SYNC_HOURS]
         ip_address = self.config_entry.data[CONF_IP_ADDRESS]
 
         allConfigData = {**self.config_entry.data}
@@ -603,7 +605,13 @@ class TapoOptionsFlowHandler(OptionsFlow):
                 else:
                     enable_media_sync = False
 
+                if MEDIA_SYNC_HOURS in user_input:
+                    media_sync_hours = user_input[MEDIA_SYNC_HOURS]
+                else:
+                    media_sync_hours = ""
+
                 allConfigData[ENABLE_MEDIA_SYNC] = enable_media_sync
+                allConfigData[MEDIA_SYNC_HOURS] = media_sync_hours
                 # todo also initial setup to add the default values!
                 self.hass.config_entries.async_update_entry(
                     self.config_entry,
@@ -635,6 +643,10 @@ class TapoOptionsFlowHandler(OptionsFlow):
                         ENABLE_MEDIA_SYNC,
                         description={"suggested_value": enable_media_sync},
                     ): bool,
+                    vol.Optional(
+                        MEDIA_SYNC_HOURS,
+                        description={"suggested_value": media_sync_hours},
+                    ): int,
                 }
             ),
             errors=errors,

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -159,7 +159,7 @@ class FlowHandler(ConfigFlow):
                 title=host,
                 data={
                     ENABLE_MEDIA_SYNC: False,
-                    MEDIA_SYNC_HOURS: "48",
+                    MEDIA_SYNC_HOURS: "",
                     MEDIA_SYNC_COLD_STORAGE_PATH: "",
                     ENABLE_MOTION_SENSOR: enable_motion_sensor,
                     ENABLE_WEBHOOKS: enable_webhooks,

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -158,6 +158,9 @@ class FlowHandler(ConfigFlow):
             return self.async_create_entry(
                 title=host,
                 data={
+                    ENABLE_MEDIA_SYNC: False,
+                    MEDIA_SYNC_HOURS: "48",
+                    MEDIA_SYNC_COLD_STORAGE_PATH: "",
                     ENABLE_MOTION_SENSOR: enable_motion_sensor,
                     ENABLE_WEBHOOKS: enable_webhooks,
                     ENABLE_STREAM: enable_stream,

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -29,6 +29,7 @@ CONF_CUSTOM_STREAM = "custom_stream"
 ENABLE_MOTION_SENSOR = "enable_motion_sensor"
 ENABLE_MEDIA_SYNC = "enable_media_sync"
 MEDIA_SYNC_HOURS = "media_sync_hours"
+MEDIA_SYNC_COLD_STORAGE_PATH = "media_sync_cold_storage_path"
 
 TOGGLE_STATES = ["on", "off"]
 

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -28,6 +28,7 @@ CONF_CUSTOM_STREAM = "custom_stream"
 
 ENABLE_MOTION_SENSOR = "enable_motion_sensor"
 ENABLE_MEDIA_SYNC = "enable_media_sync"
+MEDIA_SYNC_HOURS = "media_sync_hours"
 
 TOGGLE_STATES = ["on", "off"]
 

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -27,6 +27,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 CONF_CUSTOM_STREAM = "custom_stream"
 
 ENABLE_MOTION_SENSOR = "enable_motion_sensor"
+ENABLE_MEDIA_SYNC = "enable_media_sync"
 
 TOGGLE_STATES = ["on", "off"]
 

--- a/custom_components/tapo_control/media_source.py
+++ b/custom_components/tapo_control/media_source.py
@@ -75,9 +75,10 @@ class TapoMediaSource(MediaSource):
                 LOGGER.debug(startDate)
                 LOGGER.debug(endDate)
 
-                url = await getRecording(
+                await getRecording(
                     self.hass, tapoController, entry, date, startDate, endDate
                 )
+                url = getWebFile(entry, startDate, endDate, "videos")
                 LOGGER.debug(url)
             except Exception as e:
                 LOGGER.error(e)

--- a/custom_components/tapo_control/media_source.py
+++ b/custom_components/tapo_control/media_source.py
@@ -26,6 +26,7 @@ from .const import DOMAIN, LOGGER
 from .utils import (
     getRecording,
     getFileName,
+    getRecordings,
     getWebFile,
 )
 
@@ -164,9 +165,7 @@ class TapoMediaSource(MediaSource):
                     )
                 date = path[2]
                 tapoController: Tapo = self.hass.data[DOMAIN][entry]["controller"]
-                recordingsForDay = await self.hass.async_add_executor_job(
-                    tapoController.getRecordings, date
-                )
+                recordingsForDay = await getRecordings(self.hass, entry, date)
                 videoNames = []
                 for searchResult in recordingsForDay:
                     for key in searchResult:

--- a/custom_components/tapo_control/media_source.py
+++ b/custom_components/tapo_control/media_source.py
@@ -63,7 +63,7 @@ class TapoMediaSource(MediaSource):
                 endDate = int(path[4])
                 if (
                     self.hass.data[DOMAIN][entry]["isDownloadingStream"]
-                    and getFileName(startDate, endDate)
+                    and getFileName(startDate, endDate, False)
                     not in self.hass.data[DOMAIN][entry]["downloadedStreams"]
                 ):
                     raise Unresolvable(
@@ -191,7 +191,7 @@ class TapoMediaSource(MediaSource):
 
                 dateChildren = []
                 for data in videoNames:
-                    fileName = getFileName(data["startDate"], data["endDate"])
+                    fileName = getFileName(data["startDate"], data["endDate"], False)
                     if fileName in self.hass.data[DOMAIN][entry]["downloadedStreams"]:
                         thumbLink = getWebFile(
                             entry, data["startDate"], data["endDate"], "thumbs"

--- a/custom_components/tapo_control/media_source.py
+++ b/custom_components/tapo_control/media_source.py
@@ -71,7 +71,6 @@ class TapoMediaSource(MediaSource):
                 LOGGER.debug(startDate)
                 LOGGER.debug(endDate)
 
-                self.hass.data[DOMAIN][entry]["isDownloadingStream"] = True
                 url = await getRecording(
                     self.hass, tapoController, entry, date, startDate, endDate
                 )
@@ -115,6 +114,11 @@ class TapoMediaSource(MediaSource):
             path = item.identifier.split("/")
             if len(path) == 2:
                 entry = path[1]
+                if self.hass.data[DOMAIN][entry]["initialMediaScanDone"] is False:
+                    raise Unresolvable(
+                        "Initial local media scan still running, please try again later."
+                    )
+
                 if self.hass.data[DOMAIN][entry]["usingCloudPassword"] is False:
                     raise Unresolvable(
                         "Cloud password is required in order to play recordings.\nSet cloud password inside Settings > Devices & Services > Tapo: Cameras Control > Configure."
@@ -151,6 +155,10 @@ class TapoMediaSource(MediaSource):
                 )
             elif len(path) == 3:
                 entry = path[1]
+                if self.hass.data[DOMAIN][entry]["initialMediaScanDone"] is False:
+                    raise Unresolvable(
+                        "Initial local media scan still running, please try again later."
+                    )
                 date = path[2]
                 tapoController: Tapo = self.hass.data[DOMAIN][entry]["controller"]
                 recordingsForDay = await self.hass.async_add_executor_job(

--- a/custom_components/tapo_control/media_source.py
+++ b/custom_components/tapo_control/media_source.py
@@ -78,7 +78,7 @@ class TapoMediaSource(MediaSource):
                 await getRecording(
                     self.hass, tapoController, entry, date, startDate, endDate
                 )
-                url = getWebFile(entry, startDate, endDate, "videos")
+                url = getWebFile(self.hass, entry, startDate, endDate, "videos")
                 LOGGER.debug(url)
             except Exception as e:
                 LOGGER.error(e)
@@ -194,7 +194,11 @@ class TapoMediaSource(MediaSource):
                     fileName = getFileName(data["startDate"], data["endDate"], False)
                     if fileName in self.hass.data[DOMAIN][entry]["downloadedStreams"]:
                         thumbLink = getWebFile(
-                            entry, data["startDate"], data["endDate"], "thumbs"
+                            self.hass,
+                            entry,
+                            data["startDate"],
+                            data["endDate"],
+                            "thumbs",
                         )
 
                         dateChildren.append(

--- a/custom_components/tapo_control/sensor.py
+++ b/custom_components/tapo_control/sensor.py
@@ -111,8 +111,14 @@ class TapoSyncSensor(TapoSensorEntity):
         ]:
             self._attr_state = "Not Ready"
         elif self._hass.data[DOMAIN][self._config_entry.entry_id]["downloadProgress"]:
-            self._attr_state = self._hass.data[DOMAIN][self._config_entry.entry_id][
-                "downloadProgress"
-            ]
+            if (
+                self._hass.data[DOMAIN][self._config_entry.entry_id]["downloadProgress"]
+                == "Finished download"
+            ):
+                self._attr_state = "Idle"
+            else:
+                self._attr_state = self._hass.data[DOMAIN][self._config_entry.entry_id][
+                    "downloadProgress"
+                ]
         else:
             self._attr_state = "Idle"

--- a/custom_components/tapo_control/sensor.py
+++ b/custom_components/tapo_control/sensor.py
@@ -109,7 +109,7 @@ class TapoSyncSensor(TapoSensorEntity):
         if not self._hass.data[DOMAIN][self._config_entry.entry_id][
             "initialMediaScanDone"
         ]:
-            self._attr_state = "Starting"
+            self._attr_state = "Not Ready"
         elif self._hass.data[DOMAIN][self._config_entry.entry_id]["downloadProgress"]:
             self._attr_state = self._hass.data[DOMAIN][self._config_entry.entry_id][
                 "downloadProgress"

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -69,6 +69,12 @@
         },
         "description": "What do you want to do?"
       },
+      "media": {
+        "data": {
+          "enable_media_sync": "Enable media synchronization"
+        },
+        "description": "Modify settings of recordings media synchronization"
+      },
       "auth": {
         "data": {
           "ip_address": "IP Address",

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -71,7 +71,8 @@
       },
       "media": {
         "data": {
-          "enable_media_sync": "Enable media synchronization"
+          "enable_media_sync": "Enable media synchronization",
+          "media_sync_hours": "Number of hours to keep synchronized"
         },
         "description": "Modify settings of recordings media synchronization"
       },

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -72,7 +72,8 @@
       "media": {
         "data": {
           "enable_media_sync": "Enable media synchronization",
-          "media_sync_hours": "Number of hours to keep synchronized"
+          "media_sync_hours": "Number of hours to keep synchronized",
+          "media_sync_cold_storage_path": "Cold storage path"
         },
         "description": "Modify settings of recordings media synchronization"
       },

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -73,7 +73,7 @@
         "data": {
           "enable_media_sync": "Enable media synchronization",
           "media_sync_hours": "Number of hours to keep synchronized",
-          "media_sync_cold_storage_path": "Cold storage path"
+          "media_sync_cold_storage_path": "[Requires restart] Cold storage path"
         },
         "description": "Modify settings of recordings media synchronization"
       },

--- a/custom_components/tapo_control/tapo/entities.py
+++ b/custom_components/tapo_control/tapo/entities.py
@@ -137,6 +137,7 @@ class TapoSensorEntity(SensorEntity, TapoEntity):
         self._hass = hass
         self._attr_icon = icon
         self._attr_device_class = device_class
+        self._config_entry = config_entry
         entry["entities"].append({"entity": self, "entry": entry})
 
         TapoEntity.__init__(self, entry, name_suffix)

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -69,6 +69,12 @@
         },
         "description": "What do you want to do?"
       },
+      "media": {
+        "data": {
+          "enable_media_sync": "Enable media synchronization"
+        },
+        "description": "Modify settings of recordings media synchronization"
+      },
       "auth": {
         "data": {
           "ip_address": "IP Address",

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -71,7 +71,8 @@
       },
       "media": {
         "data": {
-          "enable_media_sync": "Enable media synchronization"
+          "enable_media_sync": "Enable media synchronization",
+          "media_sync_hours": "Number of hours to keep synchronized"
         },
         "description": "Modify settings of recordings media synchronization"
       },

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -72,7 +72,8 @@
       "media": {
         "data": {
           "enable_media_sync": "Enable media synchronization",
-          "media_sync_hours": "Number of hours to keep synchronized"
+          "media_sync_hours": "Number of hours to keep synchronized",
+          "media_sync_cold_storage_path": "Cold storage path"
         },
         "description": "Modify settings of recordings media synchronization"
       },

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -73,7 +73,7 @@
         "data": {
           "enable_media_sync": "Enable media synchronization",
           "media_sync_hours": "Number of hours to keep synchronized",
-          "media_sync_cold_storage_path": "Cold storage path"
+          "media_sync_cold_storage_path": "[Requires restart] Cold storage path"
         },
         "description": "Modify settings of recordings media synchronization"
       },

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -105,9 +105,8 @@ def getColdDirPathForEntry(hass: HomeAssistant, entry_id: str):
         if media_sync_cold_storage_path == "":
             coldDirPath = os.path.join(getDataPath(), f".storage/{DOMAIN}/{entry_id}/")
         else:
-            coldDirPath = os.path.join(
-                getDataPath(), f"{media_sync_cold_storage_path}/"
-            )
+            coldDirPath = f"{media_sync_cold_storage_path}/"
+
         pathlib.Path(coldDirPath + "/videos").mkdir(parents=True, exist_ok=True)
         pathlib.Path(coldDirPath + "/thumbs").mkdir(parents=True, exist_ok=True)
         hass.data[DOMAIN][entry_id]["mediaSyncColdDir"] = coldDirPath

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -414,8 +414,6 @@ def getHotFile(
 ):
     coldFilePath = getColdFile(hass, entry_id, startDate, endDate, folder)
     getHotDirPathForEntry(entry_id)  # ensure creation of folder structure
-    if not os.path.exists(coldFilePath):
-        raise Unresolvable("Failed to get file from cold storage: " + coldFilePath)
     extension = pathlib.Path(coldFilePath).suffix
     hotFilePath = (
         coldFilePath.replace("/.storage/", "/www/")
@@ -428,6 +426,8 @@ def getHotFile(
         + extension
     )
     if not os.path.exists(hotFilePath):
+        if not os.path.exists(coldFilePath):
+            raise Unresolvable("Failed to get file from cold storage: " + coldFilePath)
         shutil.copyfile(coldFilePath, hotFilePath)
     return hotFilePath
 

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -496,6 +496,16 @@ async def getRecording(
         if downloadedFile["currentAction"] == "Recording in progress":
             raise Unresolvable("Recording is currently in progress.")
 
+        hass.bus.fire(
+            "tapo_control_media_downloaded",
+            {
+                "entry_id": entry_id,
+                "startDate": startDate,
+                "endDate": endDate,
+                "filePath": coldFilePath,
+            },
+        )
+
     await processDownload(
         hass,
         entry_id,

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -153,7 +153,7 @@ def deleteFilesOlderThan(dirPath, deleteOlderThan):
 
 
 def processDownload(status):
-    LOGGER.debug(status)
+    LOGGER.warn(status)
 
 
 async def getRecording(
@@ -200,6 +200,9 @@ async def getRecording(
     hotFilePath = (
         coldFilePath.replace("/.storage/", "/www/").replace(".mp4", "") + UUID + ".mp4"
     )
+    # fix: what if file is not found? that can be the case, throw unresolvable!
+    if not os.path.exists(coldFilePath):
+        raise Unresolvable("Failed to download recording.")
     shutil.copyfile(coldFilePath, hotFilePath)
 
     fileWebPath = hotFilePath[hotFilePath.index("/www/") + 5 :]  # remove ./www/

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -479,7 +479,7 @@ async def getRecording(
         endDate,
     )
 
-    return getWebFile(entry_id, startDate, endDate, "videos")
+    return coldFilePath
 
 
 def areCameraPortsOpened(host):

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -129,9 +129,13 @@ async def findMedia(hass, entry_id):
                         recording[recordingKey]["endTime"],
                         "videos",
                     )
+                    filePath = getFileName(
+                        recording[recordingKey]["startTime"],
+                        recording[recordingKey]["endTime"],
+                    )
                     if os.path.exists(filePathVideo):
                         hass.data[DOMAIN][entry_id]["downloadedStreams"].append(
-                            filePathVideo
+                            filePath
                         )
                         await generateThumb(
                             hass,

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -236,6 +236,11 @@ def deleteFilesNoLongerPresentInCamera(hass, entry_id, extension, folder):
                 fileName = f.replace(extension, "")
                 filePath = os.path.join(coldDirPath + "/" + folder + "/", f)
                 if fileName not in hass.data[DOMAIN][entry_id]["mediaScanResult"]:
+                    LOGGER.warn("Removing " + filePath + " (" + fileName + ")...")
+                    hass.data[DOMAIN][entry_id]["downloadedStreams"].pop(
+                        fileName,
+                        None,
+                    )
                     os.remove(filePath)
 
 
@@ -261,6 +266,11 @@ async def deleteColdFilesOlderThanMaxSyncTime(hass, entry, extension, folder):
                 if (endTS < (int(ts) - (int(mediaSyncTime) + timeCorrection))) and (
                     ts - last_modified > int(mediaSyncTime)
                 ):
+                    LOGGER.warn("Removing " + filePath + " (" + fileName + ")...")
+                    hass.data[DOMAIN][entry_id]["downloadedStreams"].pop(
+                        fileName,
+                        None,
+                    )
                     os.remove(filePath)
 
 

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -274,7 +274,7 @@ def deleteFilesNotIncluding(dirPath, includingString):
 
 
 def processDownloadStatus(status):
-    LOGGER.debug(status)
+    LOGGER.warn(status)
 
 
 def getFileName(startDate: int, endDate: int, encrypted=False):

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -105,9 +105,7 @@ def getColdDirPathForEntry(hass: HomeAssistant, entry_id: str):
         coldDirPath = os.path.join(getDataPath(), f".storage/{DOMAIN}/{entry_id}/")
         media_sync_cold_storage_path = f".storage/{DOMAIN}/{entry_id}/"
     else:
-        coldDirPath = os.path.join(
-            getDataPath(), f"{media_sync_cold_storage_path}/{entry_id}/"
-        )
+        coldDirPath = os.path.join(getDataPath(), f"{media_sync_cold_storage_path}/")
     pathlib.Path(coldDirPath + "/videos").mkdir(parents=True, exist_ok=True)
     pathlib.Path(coldDirPath + "/thumbs").mkdir(parents=True, exist_ok=True)
     return coldDirPath

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -158,7 +158,10 @@ async def processDownload(hass, entry_id: int, startDate: int, endDate: int):
         raise Unresolvable("Failed to get file from cold storage: " + coldFilePath)
 
     if filePath not in hass.data[DOMAIN][entry_id]["downloadedStreams"]:
-        hass.data[DOMAIN][entry_id]["downloadedStreams"].append(filePath)
+        hass.data[DOMAIN][entry_id]["downloadedStreams"][filePath] = {
+            startDate: startDate,
+            endDate: endDate,
+        }
     await generateThumb(
         hass,
         entry_id,

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -236,7 +236,13 @@ def deleteFilesNoLongerPresentInCamera(hass, entry_id, extension, folder):
                 fileName = f.replace(extension, "")
                 filePath = os.path.join(coldDirPath + "/" + folder + "/", f)
                 if fileName not in hass.data[DOMAIN][entry_id]["mediaScanResult"]:
-                    LOGGER.warn("Removing " + filePath + " (" + fileName + ")...")
+                    LOGGER.warn(
+                        "[deleteFilesNoLongerPresentInCamera] Removing "
+                        + filePath
+                        + " ("
+                        + fileName
+                        + ")..."
+                    )
                     hass.data[DOMAIN][entry_id]["downloadedStreams"].pop(
                         fileName,
                         None,
@@ -266,7 +272,13 @@ async def deleteColdFilesOlderThanMaxSyncTime(hass, entry, extension, folder):
                 if (endTS < (int(ts) - (int(mediaSyncTime) + timeCorrection))) and (
                     ts - last_modified > int(mediaSyncTime)
                 ):
-                    LOGGER.warn("Removing " + filePath + " (" + fileName + ")...")
+                    LOGGER.warn(
+                        "[deleteColdFilesOlderThanMaxSyncTime] Removing "
+                        + filePath
+                        + " ("
+                        + fileName
+                        + ")..."
+                    )
                     hass.data[DOMAIN][entry_id]["downloadedStreams"].pop(
                         fileName,
                         None,
@@ -349,6 +361,7 @@ def deleteFilesOlderThan(dirPath, deleteOlderThan):
             filePath = os.path.join(dirPath, f)
             last_modified = os.stat(filePath).st_mtime
             if now - last_modified > deleteOlderThan:
+                LOGGER.warn("[deleteFilesOlderThan] Removing " + filePath + "...")
                 os.remove(filePath)
 
 
@@ -357,6 +370,7 @@ def deleteFilesNotIncluding(dirPath, includingString):
         for f in os.listdir(dirPath):
             filePath = os.path.join(dirPath, f)
             if includingString not in filePath:
+                LOGGER.warn("[deleteFilesOlderThan] Removing " + filePath + "...")
                 os.remove(filePath)
 
 

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -230,7 +230,7 @@ def getHotFile(entry_id: str, startDate: int, endDate: int, folder: str):
     coldFilePath = getColdFile(entry_id, startDate, endDate, folder)
     getHotDirPathForEntry(entry_id)  # ensure creation of folder structure
     if not os.path.exists(coldFilePath):
-        raise Unresolvable("Failed to download recording.")
+        raise Unresolvable("Failed to get file from cold storage: " + coldFilePath)
     extension = pathlib.Path(coldFilePath).suffix
     hotFilePath = (
         coldFilePath.replace("/.storage/", "/www/").replace(extension, "")
@@ -244,7 +244,6 @@ def getHotFile(entry_id: str, startDate: int, endDate: int, folder: str):
 
 def getWebFile(entry_id: str, startDate: int, endDate: int, folder: str):
     hotFilePath = getHotFile(entry_id, startDate, endDate, folder)
-    LOGGER.warn(hotFilePath)
     fileWebPath = hotFilePath[hotFilePath.index("/www/") + 5 :]  # remove ./www/
 
     return f"/local/{fileWebPath}"

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -100,10 +100,10 @@ def getDataPath():
 
 def getColdDirPathForEntry(hass: HomeAssistant, entry_id: str):
     entry: ConfigEntry = hass.data[DOMAIN][entry_id]["entry"]
+
     media_sync_cold_storage_path = entry.data.get(MEDIA_SYNC_COLD_STORAGE_PATH)
     if media_sync_cold_storage_path == "":
         coldDirPath = os.path.join(getDataPath(), f".storage/{DOMAIN}/{entry_id}/")
-        media_sync_cold_storage_path = f".storage/{DOMAIN}/{entry_id}/"
     else:
         coldDirPath = os.path.join(getDataPath(), f"{media_sync_cold_storage_path}/")
     pathlib.Path(coldDirPath + "/videos").mkdir(parents=True, exist_ok=True)

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -290,10 +290,11 @@ def processDownloadStatus(
                     if recordingCount is not False
                     else ""
                 )
-                + ": "
-                + str(round(status["progress"]))
-                + " / "
-                + str(status["total"])
+                + (
+                    ": " + str(round(status["progress"])) + " / " + str(status["total"])
+                    if status["total"] > 0
+                    else ""
+                )
             )
 
     return processUpdate


### PR DESCRIPTION
- [x] Add thumnbail generation for synced media
- [x] Add automated way to download recordings
- [x] Handle download errors gracefully
- [x] Disable manual download gracefully when download running in background
- [x] Add sensor to monitor download progress
- [x] Ability to play downloaded recordings when downloading in background
- [x] Initial media scan comparison
- [x] Stop initial media scan comparison from blocking HA start
- [x] Refactor getColdFile, getHotFile, getWebFile functions and reuse across code and videos/thumbs
- [x] Media Cleanup: Add: Delete files not including current uuid 
- [x] Display thumbnails
- [x] Change naming of files in cold storage so that they include timestamps
- [x] Fix: Generate thumbnails on manual download
- [x] Add: Threaded sync
- [x] Media Cleanup: Delete files from cold storage which are no longer in camera
- [x] ProcessDownload needs to add stuff to hass.data[DOMAIN][entry_id]["mediaScanResult"]
- [x] Media Sync needs to add stuff to hass.data[DOMAIN][entry_id]["mediaScanResult"]
- [x] User opening a folder needs to add stuff to hass.data[DOMAIN][entry_id]["mediaScanResult"]
- [x] UI: Add new category of settings
- [x] UI: Add ability to disable / enable sync
- [x] Respect chosen option to enable / disable sync
- [x] UI: Add ability to set sync time in days, when not set, sync all
- [x] Respect setting of sync time for sync
- [x] Respect setting of sync time for cleanup
- [x] Remove filename from hass.data[DOMAIN][entry_id]["downloadedStreams"] when deleted
- [x] Clear recordings older than max sync time (file modified & real file date)
- [x] Fix: getRecording should not put files into hot storage, they should be put there only if requested to be played
- [x] Events on file download
- [x] UI: Add ability to set cold folder location
- [x] findMedia needs to run periodically (does it? - yes because it needs to load new dates from camera and remove old ones)
- [x] UI migration - set correctly default values for stuff in new camera setup
- [x] UI migration - set correctly new version to stop remigrating every restart
- [x] Do not use entry_id in folder path on custom path cold storage
- [x] cleanup console logs / warnings
- [x] Documentation updates
- [x] ...?
- [x] run mkdir only once
- [x] cache getDataPath
- [ ] 
