### PR TITLE
Fix #451: Firmware 1.3.9: Incorrect Cloud credentials

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -226,6 +226,14 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             LOGGER.error(
                 "Unable to connect to Tapo: Cameras Control controller: %s", str(e)
             )
+            if "Invalid authentication data" in str(e):
+                raise ConfigEntryAuthFailed(e)
+            elif "Temporary Suspension:" in str(
+                e
+            ):  # keep retrying to authenticate eventually, or throw
+                # ConfigEntryAuthFailed on invalid auth eventually
+                raise ConfigEntryNotReady
+            # Retry for anything else
             raise ConfigEntryNotReady
 
         config_entry.version = 15

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -126,7 +126,7 @@ class FlowHandler(ConfigFlow):
                                 "[REAUTH][%s] Temporary suspension.",
                                 tapoHost,
                             )
-                            raise Exception("temporary_suspension")  # todo test this
+                            raise Exception("temporary_suspension")
                         else:
                             LOGGER.error(e)
                             raise Exception(e)

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -55,34 +55,20 @@ class FlowHandler(ConfigFlow):
         self.reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
-        return await self.async_step_reauth_confirm()
+        return await self.async_step_reauth_confirm_stream()
 
-    async def async_step_reauth_confirm(self, user_input=None):
+    async def async_step_reauth_confirm_stream(self, user_input=None):
         """Dialog that informs the user that reauth is required."""
         errors = {}
-        username = self.reauth_entry.data[CONF_USERNAME]
-        password = self.reauth_entry.data[CONF_PASSWORD]
-        cloud_password = self.reauth_entry.data[CLOUD_PASSWORD]
         tapoHost = self.reauth_entry.data[CONF_IP_ADDRESS]
         custom_stream = self.reauth_entry.data[CONF_CUSTOM_STREAM]
+        cloud_password = self.reauth_entry.data[CLOUD_PASSWORD]
+        username = self.reauth_entry.data[CONF_USERNAME]
+        password = self.reauth_entry.data[CONF_PASSWORD]
         if user_input is not None:
             username = user_input[CONF_USERNAME]
             password = user_input[CONF_PASSWORD]
-            cloud_password = user_input[CLOUD_PASSWORD]
             try:
-                LOGGER.debug(
-                    "[REAUTH][%s] Verifying cloud password.",
-                    tapoHost,
-                )
-                cloud_password = user_input[CLOUD_PASSWORD]
-                await self.hass.async_add_executor_job(
-                    registerController, tapoHost, "admin", cloud_password
-                )
-                LOGGER.debug(
-                    "[REAUTH][%s] Cloud password works for control.",
-                    tapoHost,
-                )
-
                 LOGGER.debug(
                     "[REAUTH][%s] Testing RTSP stream.",
                     tapoHost,
@@ -105,12 +91,46 @@ class FlowHandler(ConfigFlow):
                     allConfigData = {**self.reauth_entry.data}
                     allConfigData[CONF_USERNAME] = username
                     allConfigData[CONF_PASSWORD] = password
-                    allConfigData[CLOUD_PASSWORD] = cloud_password
                     self.hass.config_entries.async_update_entry(
                         self.reauth_entry,
                         title=tapoHost,
                         data=allConfigData,
                     )
+                    try:
+                        LOGGER.debug(
+                            "[REAUTH][%s] Testing control of camera using Camera Account.",
+                            tapoHost,
+                        )
+                        await self.hass.async_add_executor_job(
+                            registerController, tapoHost, username, password
+                        )
+                        LOGGER.debug(
+                            "[REAUTH][%s] Camera Account works for control.",
+                            tapoHost,
+                        )
+                        if cloud_password != "":
+                            LOGGER.debug(
+                                "[REAUTH][%s] Cloud password is not empty, requesting validation.",
+                                tapoHost,
+                            )
+                            return await self.async_step_reauth_confirm_cloud()
+                    except Exception as e:
+                        if str(e) == "Invalid authentication data":
+                            LOGGER.debug(
+                                "[REAUTH][%s] Camera Account does not work for control, requesting cloud password.",
+                                tapoHost,
+                            )
+                            return await self.async_step_reauth_confirm_cloud()
+                        elif "Temporary Suspension" in str(e):
+                            LOGGER.debug(
+                                "[REAUTH][%s] Temporary suspension.",
+                                tapoHost,
+                            )
+                            raise Exception("temporary_suspension")  # todo test this
+                        else:
+                            LOGGER.error(e)
+                            raise Exception(e)
+
                     await self.hass.config_entries.async_reload(
                         self.reauth_entry.entry_id
                     )
@@ -136,7 +156,10 @@ class FlowHandler(ConfigFlow):
                         tapoHost,
                     )
                     errors["base"] = "invalid_stream_auth"
-                elif "Temporary Suspension" in str(e):
+                elif (
+                    "Temporary Suspension" in str(e)
+                    or str(e) == "temporary_suspension"  # todo: test this
+                ):
                     LOGGER.debug(
                         "[REAUTH][%s] Temporary suspension.",
                         tapoHost,
@@ -146,11 +169,11 @@ class FlowHandler(ConfigFlow):
                     errors["base"] = "unknown"
                     LOGGER.error(e)
         LOGGER.debug(
-            "[REAUTH][%s] Showing config flow for reauth.",
+            "[REAUTH][%s] Showing config flow for reauth - stream.",
             tapoHost,
         )
         return self.async_show_form(
-            step_id="reauth_confirm",
+            step_id="reauth_confirm_stream",
             data_schema=vol.Schema(
                 {
                     vol.Required(
@@ -159,9 +182,79 @@ class FlowHandler(ConfigFlow):
                     vol.Required(
                         CONF_PASSWORD, description={"suggested_value": password}
                     ): str,
+                }
+            ),
+            errors=errors,
+            last_step=True,
+        )
+
+    async def async_step_reauth_confirm_cloud(self, user_input=None):
+        errors = {}
+        tapoHost = self.reauth_entry.data[CONF_IP_ADDRESS]
+        cloudPassword = self.reauth_entry.data[CLOUD_PASSWORD]
+        if user_input is not None:
+            cloudPassword = user_input[CLOUD_PASSWORD]
+            try:
+                LOGGER.debug(
+                    "[REAUTH][%s] Testing control of camera using Cloud Account.",
+                    tapoHost,
+                )
+                await self.hass.async_add_executor_job(
+                    registerController, tapoHost, "admin", cloudPassword
+                )
+                LOGGER.debug(
+                    "[REAUTH][%s] Cloud Account works for control.",
+                    tapoHost,
+                )
+                allConfigData = {**self.reauth_entry.data}
+                allConfigData[CLOUD_PASSWORD] = cloudPassword
+                self.hass.config_entries.async_update_entry(
+                    self.reauth_entry,
+                    title=tapoHost,
+                    data=allConfigData,
+                )
+                await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+            except Exception as e:
+                if "Failed to establish a new connection" in str(e):
+                    LOGGER.debug(
+                        "[REAUTH][%s] Connection failed.",
+                        tapoHost,
+                    )
+                    errors["base"] = "connection_failed"
+                    LOGGER.error(e)
+                elif str(e) == "Invalid authentication data":
+                    LOGGER.debug(
+                        "[REAUTH][%s] Invalid cloud password provided.",
+                        tapoHost,
+                    )
+                    errors["base"] = "invalid_auth_cloud"
+                elif str(e) == "Invalid stream authentication data":
+                    LOGGER.debug(
+                        "[REAUTH][%s] Invalid 3rd party account password provided.",
+                        tapoHost,
+                    )
+                    errors["base"] = "invalid_stream_auth"
+                elif "Temporary Suspension" in str(e):  # tested
+                    LOGGER.debug(
+                        "[REAUTH][%s] Temporary suspension.",
+                        tapoHost,
+                    )
+                    errors["base"] = str(e)
+                else:
+                    errors["base"] = "unknown"
+                    LOGGER.error(e)
+        LOGGER.debug(
+            "[REAUTH][%s] Showing config flow for reauth - cloud.",
+            tapoHost,
+        )
+        return self.async_show_form(
+            step_id="reauth_confirm_cloud",
+            data_schema=vol.Schema(
+                {
                     vol.Required(
-                        CLOUD_PASSWORD,
-                        description={"suggested_value": cloud_password},
+                        CLOUD_PASSWORD, description={"suggested_value": cloudPassword}
                     ): str,
                 }
             ),

--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -8,7 +8,7 @@
   ],
   "version": "5.4.0",
   "requirements": [
-    "pytapo==3.3.3"
+    "pytapo==3.3.4"
   ],
   "dependencies": [
     "ffmpeg",

--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -8,7 +8,7 @@
   ],
   "version": "5.4.0",
   "requirements": [
-    "pytapo==3.3.4"
+    "pytapo==3.3.5"
   ],
   "dependencies": [
     "ffmpeg",

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -3,13 +3,18 @@
   "config": {
     "flow_title": "Tapo: Cameras Control {name}",
     "step": {
-      "reauth_confirm": {
+      "reauth_confirm_stream": {
         "data": {
           "username": "Camera Account - Username",
-          "password": "Camera Account - Password",
+          "password": "Camera Account - Password"
+        },
+        "description": "Your password(s) changed. Please enter up to date passwords.\n\nCamera account is created via Tapo app at:\nCamera Settings > Advanced Settings > Camera Account.\n\nYou can test if these credentials work via rtsp stream, for example VLC using link\nrtsp://username:password@IP Address:554/stream1"
+      },
+      "reauth_confirm_cloud": {
+        "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Your password(s) changed. Please enter up to date passwords."
+        "description": "Camera requires your cloud password for control.\nThis is the password you used for your Tapo Cloud account with your email.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
       },
       "ip": {
         "data": {

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -3,13 +3,18 @@
   "config": {
     "flow_title": "Tapo: Cameras Control {name}",
     "step": {
-      "reauth_confirm": {
+      "reauth_confirm_stream": {
         "data": {
           "username": "Camera Account - Username",
-          "password": "Camera Account - Password",
+          "password": "Camera Account - Password"
+        },
+        "description": "Your password(s) changed. Please enter up to date passwords.\n\nCamera account is created via Tapo app at:\nCamera Settings > Advanced Settings > Camera Account.\n\nYou can test if these credentials work via rtsp stream, for example VLC using link\nrtsp://username:password@IP Address:554/stream1"
+      },
+      "reauth_confirm_cloud": {
+        "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Your password(s) changed. Please enter up to date passwords."
+        "description": "Camera requires your cloud password for control.\nThis is the password you used for your Tapo Cloud account with your email.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
       },
       "ip": {
         "data": {


### PR DESCRIPTION
### Fixes

- Fix #451: Some cameras after the latest firmware upgrade stick to their MD5 hash of cloud password instead of generating a new SHA256 resulting in failed authorization if trying with the new hash. Change introduced automatically detects the hashing algorithm and applies it. If camera changes the hashing algorithm, it will automatically detect a new one.
- Update: Re-authorization request now respects old firmwares and keeps cloud password optional