### PR TITLE
Added readme instructions for the cloud password not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ As well as:
 
 </details>
 
+<details>
+  <summary>I see error `Invalid cloud password. Invalid cloud password. Make sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same). You need to enter password which you used with your email when signing into the Tapo app.` when I enter correct password</summary>
+
+  Try those troubleshooting options:
+
+  1. Make sure that "Two-Step Verification" for login is disabled. Go in the Tapo app > Me > View Account > Login Security > Turn off the "Two-Step Verification".
+  2. Reset your password.
+  3. Make sure your camera can access the internet.
+  4. Reboot your camera a few times.
+  5. Reset the camera. Remove it from your account, do a factory reset, add it back with internet access, add it back to the integration.
+
+</details>
 
 <details>
   <summary>Supported models</summary>


### PR DESCRIPTION
I installed the integration yesterday and couldn't get the cloud password to work despite following the troubleshooting steps mentioned in the various issues.

It turned out that 2-factor authentication was enabled on my Tapo account, which does not work with the integration.

This PR adds general instructions on what to try if the user encounters the error saying that the cloud password does not work. It includes the steps that are generally shared in the issues, but also adds the one to disable 2FA first.