### PR TITLE
Implement color mode (compatibility enhancement)

### DIFF
--- a/custom_components/tapo_control/light.py
+++ b/custom_components/tapo_control/light.py
@@ -1,5 +1,6 @@
 from homeassistant.core import HomeAssistant
 
+from homeassistant.components.light import ColorMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -54,6 +55,8 @@ class TapoWhitelight(TapoLightEntity):
     def __init__(self, entry: dict, hass: HomeAssistant, config_entry):
         LOGGER.debug("TapoWhitelight - init - start")
         self._attr_is_on = False
+        self._attr_color_mode = ColorMode.ONOFF
+        self._attr_supported_color_modes = set([ColorMode.ONOFF])
         self._hass = hass
 
         TapoLightEntity.__init__(
@@ -116,6 +119,8 @@ class TapoFloodlight(TapoLightEntity):
     def __init__(self, entry: dict, hass: HomeAssistant, config_entry):
         LOGGER.debug("TapoFloodlight - init - start")
         self._attr_is_on = False
+        self._attr_color_mode = ColorMode.ONOFF
+        self._attr_supported_color_modes = set([ColorMode.ONOFF])
         self._hass = hass
 
         TapoLightEntity.__init__(


### PR DESCRIPTION
Reference:
https://developers.home-assistant.io/docs/core/entity/light#color-modes

> New integrations must implement both color_mode and supported_color_modes.
> If an integration is upgraded to support color mode, both color_mode and
> supported_color_modes should be implemented.

This also fixes this warning at startup:

```
WARNING (MainThread) [homeassistant.components.light] None (<class 'custom_components.tapo_control.light.TapoWhitelight'>) does not set supported color modes, this will stop working in Home Assistant Core 2025.3, please create a bug report at https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues
```