### PR TITLE
Add #667: Media Sync switch entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,9 @@ Integration is capable of synchronizing recordings for fast playback.
 
 Synchronization is turned off by default, you can browse media stored on camera and request it to be played. However, downloading is rather slow, so it is a good idea to enable media synchronization in background. That way, you will be able to play any synchronized media from camera instantly.
 
-You can enable this setting by navigating to Home Assistant Settings -> Devices and clicking on Configure button next to the Tapo device you wish to turn media synchronization on for.
+You can enable this setting by navigating to Home Assistant Settings -> Devices and clicking on Configure button next to the Tapo device you wish to turn media synchronization on for. Here, you need to define the number of hours to synchronize. Unless it is specified, synchronization does not run. Here, you are able to also set the storage path where the synchronized recordings will be stored (defaults to /config/.storage/tapo_control).
 
-You need to also define the number of hours to synchronize. Unless it is specified, synchronization does not run.
-
-Finally, you are able to set the storage path where the synchronized recordings will be stored (defaults to /config/.storage/tapo_control).
+Finally, you can turn on, or off switch entity `switch.*_media_sync`.
 
 **Notice:**: Recordings are deleted after the number of hours you have chosen to synchronize passes, once both the actual recording time and the file modified time is older than the number of hours set.
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -833,7 +833,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         # todo move to utils
         async def mediaSync(time=None):
-            LOGGER.warning("mediaSync")
+            LOGGER.debug("mediaSync")
             hass.data[DOMAIN][entry.entry_id]["mediaSyncRanOnce"] = True
             enableMediaSync = hass.data[DOMAIN][entry.entry_id][ENABLE_MEDIA_SYNC]
             mediaSyncHours = entry.data.get(MEDIA_SYNC_HOURS)
@@ -855,11 +855,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                     tapoController: Tapo = hass.data[DOMAIN][entry.entry_id][
                         "controller"
                     ]
-                    LOGGER.warning("getRecordingsList -1")
+                    LOGGER.debug("getRecordingsList -1")
                     recordingsList = await hass.async_add_executor_job(
                         tapoController.getRecordingsList
                     )
-                    LOGGER.warning("getRecordingsList -2")
+                    LOGGER.debug("getRecordingsList -2")
 
                     ts = datetime.datetime.utcnow().timestamp()
                     for searchResult in recordingsList:
@@ -881,11 +881,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                     )
                                 )
                             ):
-                                LOGGER.warning("getRecordings -1")
+                                LOGGER.debug("getRecordings -1")
                                 recordingsForDay = await getRecordings(
                                     hass, entry.entry_id, searchResult[key]["date"]
                                 )
-                                LOGGER.warning("getRecordings -2")
+                                LOGGER.debug("getRecordings -2")
                                 totalRecordingsToDownload = 0
                                 for recording in recordingsForDay:
                                     for recordingKey in recording:
@@ -905,7 +905,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                                     entry.entry_id
                                                 ][ENABLE_MEDIA_SYNC]
                                                 if enableMediaSync:
-                                                    LOGGER.warning("getRecording -1")
+                                                    LOGGER.debug("getRecording -1")
                                                     await getRecording(
                                                         hass,
                                                         tapoController,
@@ -920,9 +920,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                                         recordingCount,
                                                         totalRecordingsToDownload,
                                                     )
-                                                    LOGGER.warning("getRecording -2")
+                                                    LOGGER.debug("getRecording -2")
                                                 else:
-                                                    LOGGER.warning(
+                                                    LOGGER.debug(
                                                         f"Media sync disabled (inside getRecording): {enableMediaSync}"
                                                     )
                                             except Unresolvable as err:
@@ -937,15 +937,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                                 hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] = False
                                                 LOGGER.error(err)
                             else:
-                                LOGGER.warning(
+                                LOGGER.debug(
                                     f"Media sync ignoring {searchResult[key]["date"]}. Media sync: {enableMediaSync}."
                                 )
                 except Exception as err:
                     LOGGER.error(err)
-                LOGGER.warning("runningMediaSync -false")
+                LOGGER.debug("runningMediaSync -false")
                 hass.data[DOMAIN][entry.entry_id]["runningMediaSync"] = False
             else:
-                LOGGER.warning(
+                LOGGER.debug(
                     f"Media sync disabled (inside mediaSync): {enableMediaSync}"
                 )
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -308,6 +308,9 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     coldDirPath = getColdDirPathForEntry(hass, entry_id)
     hotDirPath = getHotDirPathForEntry(hass, entry_id)
 
+    entry_storage = Store(hass, version=1, key=getEntryStorageFile(entry))
+    await entry_storage.async_remove()
+
     # Delete all media stored in cold storage for entity
     if coldDirPath:
         LOGGER.debug("Deleting cold storage files for entity " + entry_id + "...")

--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -23,15 +23,13 @@ from homeassistant.helpers.entity import EntityCategory
 from .const import (
     BRAND,
     DOMAIN,
-    ENABLE_MEDIA_SYNC,
     LOGGER,
     ENABLE_SOUND_DETECTION,
-    MEDIA_SYNC_HOURS,
     SOUND_DETECTION_PEAK,
     SOUND_DETECTION_DURATION,
     SOUND_DETECTION_RESET,
 )
-from .utils import build_device_info, getColdDirPathForEntry, getStreamSource
+from .utils import build_device_info, getStreamSource
 from .tapo.entities import TapoBinarySensorEntity
 
 import haffmpeg.sensor as ffmpeg_sensor
@@ -55,48 +53,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         LOGGER.debug("Adding TapoNoiseBinarySensor...")
         binarySensors.append(TapoNoiseBinarySensor(entry, hass, config_entry))
 
-    binarySensors.append(TapoMediaSyncEnabledSensor(entry, hass, config_entry))
-
     if binarySensors:
         async_add_entities(binarySensors)
 
     return True
-
-
-class TapoMediaSyncEnabledSensor(TapoBinarySensorEntity):
-    def __init__(self, entry: dict, hass: HomeAssistant, config_entry):
-        LOGGER.debug("TapoMediaSyncEnabledSensor - init - start")
-        self._config_entry = config_entry
-        self.latestCamData = entry["camData"]
-        self._hass = hass
-        self._attr_extra_state_attributes = {}
-        TapoBinarySensorEntity.__init__(
-            self,
-            "Media Sync Enabled",
-            entry,
-            hass,
-            config_entry,
-            None,
-        )
-        self.updateTapo(self.latestCamData)
-
-        LOGGER.debug("TapoMediaSyncEnabledSensor - init - end")
-
-    def updateTapo(self, camData):
-        enableMediaSync = self._config_entry.data.get(ENABLE_MEDIA_SYNC)
-        mediaSyncHours = self._config_entry.data.get(MEDIA_SYNC_HOURS)
-        if enableMediaSync and mediaSyncHours:
-            self._attr_state = STATE_ON
-        else:
-            self._attr_state = STATE_OFF
-        self._attr_extra_state_attributes["sync_hours"] = mediaSyncHours
-        self._attr_extra_state_attributes["storage_path"] = getColdDirPathForEntry(
-            self._hass, self._config_entry.entry_id
-        )
-
-    @property
-    def entity_category(self):
-        return EntityCategory.DIAGNOSTIC
 
 
 class TapoNoiseBinarySensor(TapoBinarySensorEntity):

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -16,7 +16,6 @@ from .utils import (
 )
 from .const import (
     DOMAIN,
-    ENABLE_MEDIA_SYNC,
     ENABLE_MOTION_SENSOR,
     ENABLE_STREAM,
     ENABLE_SOUND_DETECTION,
@@ -47,7 +46,7 @@ from .const import (
 class FlowHandler(ConfigFlow):
     """Handle a config flow."""
 
-    VERSION = 16
+    VERSION = 17
 
     @staticmethod
     def async_get_options_flow(config_entry):
@@ -397,7 +396,6 @@ class FlowHandler(ConfigFlow):
                 data={
                     MEDIA_VIEW_DAYS_ORDER: "Ascending",
                     MEDIA_VIEW_RECORDINGS_ORDER: "Ascending",
-                    ENABLE_MEDIA_SYNC: False,
                     MEDIA_SYNC_HOURS: "",
                     MEDIA_SYNC_COLD_STORAGE_PATH: "",
                     ENABLE_MOTION_SENSOR: enable_motion_sensor,
@@ -1012,7 +1010,6 @@ class TapoOptionsFlowHandler(OptionsFlow):
             "[%s] Opened Tapo options - media.", self.config_entry.data[CONF_IP_ADDRESS]
         )
         errors = {}
-        enable_media_sync = self.config_entry.data[ENABLE_MEDIA_SYNC]
         media_view_days_order = self.config_entry.data[MEDIA_VIEW_DAYS_ORDER]
         media_view_recordings_order = self.config_entry.data[
             MEDIA_VIEW_RECORDINGS_ORDER
@@ -1025,10 +1022,6 @@ class TapoOptionsFlowHandler(OptionsFlow):
         allConfigData = {**self.config_entry.data}
         if user_input is not None:
             try:
-                if ENABLE_MEDIA_SYNC in user_input:
-                    enable_media_sync = user_input[ENABLE_MEDIA_SYNC]
-                else:
-                    enable_media_sync = False
 
                 if MEDIA_VIEW_DAYS_ORDER in user_input:
                     media_view_days_order = user_input[MEDIA_VIEW_DAYS_ORDER]
@@ -1054,7 +1047,6 @@ class TapoOptionsFlowHandler(OptionsFlow):
                 else:
                     media_sync_cold_storage_path = ""
 
-                allConfigData[ENABLE_MEDIA_SYNC] = enable_media_sync
                 allConfigData[MEDIA_VIEW_DAYS_ORDER] = media_view_days_order
                 allConfigData[MEDIA_VIEW_RECORDINGS_ORDER] = media_view_recordings_order
                 allConfigData[MEDIA_SYNC_HOURS] = media_sync_hours
@@ -1082,10 +1074,6 @@ class TapoOptionsFlowHandler(OptionsFlow):
                         MEDIA_VIEW_RECORDINGS_ORDER,
                         description={"suggested_value": media_view_recordings_order},
                     ): vol.In(MEDIA_VIEW_RECORDINGS_ORDER_OPTIONS),
-                    vol.Optional(
-                        ENABLE_MEDIA_SYNC,
-                        description={"suggested_value": enable_media_sync},
-                    ): bool,
                     vol.Optional(
                         MEDIA_SYNC_HOURS,
                         description={"suggested_value": media_sync_hours},

--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -6,7 +6,7 @@
   "codeowners": [
     "@JurajNyiri"
   ],
-  "version": "5.6.3",
+  "version": "5.8.0",
   "requirements": [
     "pytapo==3.3.32"
   ],

--- a/custom_components/tapo_control/sensor.py
+++ b/custom_components/tapo_control/sensor.py
@@ -295,15 +295,15 @@ class TapoSyncSensor(TapoSensorEntity):
         runningMediaSync = self._hass.data[DOMAIN][self._config_entry.entry_id][
             "runningMediaSync"
         ]
-        LOGGER.warning("Enable Media Sync: %s", enable_media_sync)
+        LOGGER.debug("Enable Media Sync: %s", enable_media_sync)
         if enable_media_sync or runningMediaSync is True:
             data = self._hass.data[DOMAIN][self._config_entry.entry_id]
-            LOGGER.warning("Initial Media Scan: %s", data["initialMediaScanDone"])
-            LOGGER.warning("Media Sync Available: %s", data["mediaSyncAvailable"])
-            LOGGER.warning("Download Progress: %s", data["downloadProgress"])
-            LOGGER.warning("Running media sync: %s", data["runningMediaSync"])
-            LOGGER.warning("Media Sync Schedueled: %s", data["mediaSyncScheduled"])
-            LOGGER.warning("Media Sync Ran Once: %s", data["mediaSyncRanOnce"])
+            LOGGER.debug("Initial Media Scan: %s", data["initialMediaScanDone"])
+            LOGGER.debug("Media Sync Available: %s", data["mediaSyncAvailable"])
+            LOGGER.debug("Download Progress: %s", data["downloadProgress"])
+            LOGGER.debug("Running media sync: %s", data["runningMediaSync"])
+            LOGGER.debug("Media Sync Schedueled: %s", data["mediaSyncScheduled"])
+            LOGGER.debug("Media Sync Ran Once: %s", data["mediaSyncRanOnce"])
 
             if not data["initialMediaScanDone"] or (
                 data["initialMediaScanDone"] and not data["mediaSyncRanOnce"]

--- a/custom_components/tapo_control/sensor.py
+++ b/custom_components/tapo_control/sensor.py
@@ -289,16 +289,21 @@ class TapoSyncSensor(TapoSensorEntity):
 
     def updateTapo(self, camData: dict | None) -> None:
         """Update the entity."""
-        enable_media_sync = self._config_entry.data.get(ENABLE_MEDIA_SYNC)
-        LOGGER.debug("Enable Media Sync: %s", enable_media_sync)
-        if enable_media_sync:
+        enable_media_sync = self._hass.data[DOMAIN][self._config_entry.entry_id][
+            ENABLE_MEDIA_SYNC
+        ]
+        runningMediaSync = self._hass.data[DOMAIN][self._config_entry.entry_id][
+            "runningMediaSync"
+        ]
+        LOGGER.warning("Enable Media Sync: %s", enable_media_sync)
+        if enable_media_sync or runningMediaSync is True:
             data = self._hass.data[DOMAIN][self._config_entry.entry_id]
-            LOGGER.debug("Initial Media Scan: %s", data["initialMediaScanDone"])
-            LOGGER.debug("Media Sync Available: %s", data["mediaSyncAvailable"])
-            LOGGER.debug("Download Progress: %s", data["downloadProgress"])
-            LOGGER.debug("Running media sync: %s", data["runningMediaSync"])
-            LOGGER.debug("Media Sync Schedueled: %s", data["mediaSyncScheduled"])
-            LOGGER.debug("Media Sync Ran Once: %s", data["mediaSyncRanOnce"])
+            LOGGER.warning("Initial Media Scan: %s", data["initialMediaScanDone"])
+            LOGGER.warning("Media Sync Available: %s", data["mediaSyncAvailable"])
+            LOGGER.warning("Download Progress: %s", data["downloadProgress"])
+            LOGGER.warning("Running media sync: %s", data["runningMediaSync"])
+            LOGGER.warning("Media Sync Schedueled: %s", data["mediaSyncScheduled"])
+            LOGGER.warning("Media Sync Ran Once: %s", data["mediaSyncRanOnce"])
 
             if not data["initialMediaScanDone"] or (
                 data["initialMediaScanDone"] and not data["mediaSyncRanOnce"]

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -98,7 +98,6 @@
         "data": {
           "media_view_days_order": "Order of days in Media Browser",
           "media_view_recordings_order": "Order of recordings in Media Browser",
-          "enable_media_sync": "Enable media synchronization",
           "media_sync_hours": "Number of hours to keep synchronized",
           "media_sync_cold_storage_path": "[Requires restart] Cold storage path"
         },

--- a/custom_components/tapo_control/switch.py
+++ b/custom_components/tapo_control/switch.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
             LOGGER.debug("Adding tapoPrivacySwitch...")
             switches.append(tapoPrivacySwitch)
 
-        if ENABLE_MEDIA_SYNC not in entry_stored_data:
+        if entry_stored_data is None or ENABLE_MEDIA_SYNC not in entry_stored_data:
             await entry_storage.async_save({ENABLE_MEDIA_SYNC: False})
             entry_stored_data = await entry_storage.async_load()
 

--- a/custom_components/tapo_control/switch.py
+++ b/custom_components/tapo_control/switch.py
@@ -1,12 +1,13 @@
 from homeassistant.core import HomeAssistant
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.helpers.storage import Store
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, ENABLE_MEDIA_SYNC, MEDIA_SYNC_HOURS
 from .tapo.entities import TapoSwitchEntity
-from .utils import check_and_create
+from .utils import check_and_create, getColdDirPathForEntry, getEntryStorageFile
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -24,6 +25,8 @@ async def async_setup_entry(
     switches = []
 
     async def setupEntities(entry):
+        entry_storage = Store(hass, version=1, key=getEntryStorageFile(config_entry))
+        entry_stored_data = await entry_storage.async_load()
         switches = []
         tapoPrivacySwitch = await check_and_create(
             entry, hass, TapoPrivacySwitch, "getPrivacyMode", config_entry
@@ -31,6 +34,21 @@ async def async_setup_entry(
         if tapoPrivacySwitch:
             LOGGER.debug("Adding tapoPrivacySwitch...")
             switches.append(tapoPrivacySwitch)
+
+        if ENABLE_MEDIA_SYNC not in entry_stored_data:
+            await entry_storage.async_save({ENABLE_MEDIA_SYNC: False})
+            entry_stored_data = await entry_storage.async_load()
+
+        tapoEnableMediaSyncSwitch = TapoEnableMediaSyncSwitch(
+            entry,
+            hass,
+            config_entry,
+            entry_storage,
+            entry_stored_data[ENABLE_MEDIA_SYNC],
+        )
+        if tapoEnableMediaSyncSwitch:
+            LOGGER.debug("Adding TapoEnableMediaSyncSwitch...")
+            switches.append(tapoEnableMediaSyncSwitch)
 
         tapoLensDistortionCorrectionSwitch = await check_and_create(
             entry,
@@ -174,6 +192,46 @@ async def async_setup_entry(
         async_add_entities(switches)
     else:
         LOGGER.debug("No switch entities available.")
+
+
+class TapoEnableMediaSyncSwitch(TapoSwitchEntity):
+    def __init__(
+        self,
+        entry: dict,
+        hass: HomeAssistant,
+        config_entry,
+        entry_storage: Store,
+        savedValue: bool,
+    ):
+        self._attr_extra_state_attributes = {}
+        TapoSwitchEntity.__init__(
+            self,
+            "Media Sync",
+            entry,
+            hass,
+            config_entry,
+            "mdi:sync",
+        )
+        self._entry_storage = entry_storage
+        self._attr_state = "on" if savedValue else "off"
+        hass.data[DOMAIN][config_entry.entry_id][ENABLE_MEDIA_SYNC] = savedValue
+
+    async def async_turn_on(self) -> None:
+        await self._entry_storage.async_save({ENABLE_MEDIA_SYNC: True})
+        self._hass.data[DOMAIN][self._config_entry.entry_id][ENABLE_MEDIA_SYNC] = True
+        self._attr_state = "on"
+
+    async def async_turn_off(self) -> None:
+        await self._entry_storage.async_save({ENABLE_MEDIA_SYNC: False})
+        self._hass.data[DOMAIN][self._config_entry.entry_id][ENABLE_MEDIA_SYNC] = False
+        self._attr_state = "off"
+
+    def updateTapo(self, camData):
+        mediaSyncHours = self._config_entry.data.get(MEDIA_SYNC_HOURS)
+        self._attr_extra_state_attributes["sync_hours"] = mediaSyncHours
+        self._attr_extra_state_attributes["storage_path"] = getColdDirPathForEntry(
+            self._hass, self._config_entry.entry_id
+        )
 
 
 class TapoHDRSwitch(TapoSwitchEntity):

--- a/custom_components/tapo_control/tapo/entities.py
+++ b/custom_components/tapo_control/tapo/entities.py
@@ -109,6 +109,7 @@ class TapoSwitchEntity(SwitchEntity, TapoEntity):
         self._attr_is_on = False
         self._hass = hass
         self._attr_icon = icon
+        self._config_entry = config_entry
         self._attr_device_class = device_class
         entry["entities"].append({"entity": self, "entry": entry})
         self.updateTapo(entry["camData"])

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -98,7 +98,6 @@
         "data": {
           "media_view_days_order": "Order of days in Media Browser",
           "media_view_recordings_order": "Order of recordings in Media Browser",
-          "enable_media_sync": "Enable media synchronization",
           "media_sync_hours": "Number of hours to keep synchronized",
           "media_sync_cold_storage_path": "[Requires restart] Cold storage path"
         },

--- a/custom_components/tapo_control/translations/ru.json
+++ b/custom_components/tapo_control/translations/ru.json
@@ -98,7 +98,6 @@
         "data": {
           "media_view_days_order": "Порядок дней в браузере медиа",
           "media_view_recordings_order": "Порядок записей в браузере медиа",
-          "enable_media_sync": "Включить синхронизацию медиа",
           "media_sync_hours": "Количество часов для синхронизации",
           "media_sync_cold_storage_path": "[Требуется перезапуск] Путь к постоянному хранилищу"
         },

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -174,6 +174,10 @@ async def getRecordings(hass, entry_id, date):
     return recordingsForDay
 
 
+def getEntryStorageFile(config_entry):
+    return f"tapo_control_{config_entry.entry_id}"
+
+
 # todo: findMedia needs to run periodically
 async def findMedia(hass, entry):
     entry_id = entry.entry_id


### PR DESCRIPTION
# Todo:

- [x] Test with initial setup of camera
- [x] Test turning off/on during run
- [x] Change warnings to debug logs once tested
- [x] Code cleanup

# Breaking Changes

- `binary_sensor.*_media_sync_enabled` entity is no longer present. It was replaced by `switch.*_media_sync` entity (along with extra attributes).
- Media Sync is no longer enabled or disabled via configuration of device, it is now instead controlled via entity `switch.*_media_sync`. Your current setting will be automatically migrated into this new entity.

### Notes

- Even when `switch.*_media_sync` is enabled, you still need to define number of hours to synchronize via configuration of device in Home Assistant. See [readme](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control?tab=readme-ov-file#media-sync) for more information.