### PR TITLE
Remove async_unload_entry code from platforms

### DIFF
--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -37,10 +37,6 @@ from .tapo.entities import TapoBinarySensorEntity
 import haffmpeg.sensor as ffmpeg_sensor
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return True
-
-
 async def async_setup_entry(hass, config_entry, async_add_entities):
     LOGGER.debug("Setting up binary sensor for motion.")
     entry = hass.data[DOMAIN][config_entry.entry_id]

--- a/custom_components/tapo_control/button.py
+++ b/custom_components/tapo_control/button.py
@@ -11,10 +11,6 @@ from .tapo.entities import TapoButtonEntity
 from .utils import syncTime, check_and_create
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return True
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -33,10 +33,6 @@ from .const import (
 from .utils import build_device_info, getStreamSource
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return True
-
-
 async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
 ):

--- a/custom_components/tapo_control/light.py
+++ b/custom_components/tapo_control/light.py
@@ -11,10 +11,6 @@ from .tapo.entities import TapoLightEntity
 from .utils import check_and_create
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return True
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,

--- a/custom_components/tapo_control/number.py
+++ b/custom_components/tapo_control/number.py
@@ -11,10 +11,6 @@ from .tapo.entities import TapoEntity, TapoNumberEntity
 from .utils import check_and_create
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return True
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,

--- a/custom_components/tapo_control/select.py
+++ b/custom_components/tapo_control/select.py
@@ -8,10 +8,6 @@ from .tapo.entities import TapoSelectEntity
 from .utils import check_and_create, getNightModeName, getNightModeValue
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return True
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,

--- a/custom_components/tapo_control/siren.py
+++ b/custom_components/tapo_control/siren.py
@@ -11,10 +11,6 @@ from .tapo.entities import TapoEntity
 from .utils import check_and_create
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return True
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,

--- a/custom_components/tapo_control/switch.py
+++ b/custom_components/tapo_control/switch.py
@@ -9,10 +9,6 @@ from .tapo.entities import TapoSwitchEntity
 from .utils import check_and_create
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return True
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,


### PR DESCRIPTION
This `async_unload_entry` section of code is never called when unloading platforms, so this just cleans that up from the respective domains.