### PR TITLE
Add: Instructions about Third Party Integration in official Tapo App

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,6 @@
 
 Custom component - Tapo: Cameras Control - to add Tapo cameras into Home Assistant
 
-## Integration does not work temporarily on firmware build 230921 and higher
-
-TP-Link is currently working on a solution that will fixed this issue. 
-
-If you wish to use this integration, until this issue is resolved, you will need to either:
-
-1. If your camera still works with integration: Block internet access of camera if you are using firmware build 230921 and higher
-2. If your camera no longer works with integration: [Block internet access and factory reset camera](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/blob/main/add_camera_with_new_firmware.md) or [Use older firmware](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/discussions/625) than build 230921 and optionally factory reset camera
-
-[Learn more, get latest updates](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/551), [ask a question](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/discussions/categories/q-a) or [discuss](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/discussions/categories/discuss).
-
 ## Installation
 
 Copy contents of custom_components/tapo_control/ to custom_components/tapo_control/ in your Home Assistant config folder.
@@ -195,17 +184,14 @@ As well as:
 </details>
 
 <details>
-  <summary>I see error `Invalid cloud password. Invalid cloud password. Make sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same). You need to enter password which you used with your email when signing into the Tapo app.` when I enter correct password</summary>
+  <summary>I see error `Invalid cloud password.`</summary>
 
-  If you are using firmware build 230921 and higher, check issue https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/551.
-
-  Otherwise, try those troubleshooting options:
-
-  1. Make sure that "Two-Step Verification" for login is disabled. Go in the Tapo app > Me > View Account > Login Security > Turn off the "Two-Step Verification".
-  2. Reset your password.
-  3. Make sure your camera can access the internet.
-  4. Reboot your camera a few times.
-  5. Reset the camera. Remove it from your account, do a factory reset, add it back with internet access, add it back to the integration.
+  1. Ensure you have Third Party Compatibility turned on in official Tapo app on your smartphone. Tapo App -> Me -> Tapo Lab -> Third-Party Compatibility -> On
+  2. Make sure that "Two-Step Verification" for login is disabled. Go in the Tapo app > Me > View Account > Login Security > Turn off the "Two-Step Verification".
+  3. Reset your password.
+  4. Make sure your camera can access the internet.
+  5. Reboot your camera a few times.
+  6. Reset the camera. Remove it from your account, do a factory reset, add it back with internet access, add it back to the integration.
 
 </details>
 

--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -6,7 +6,7 @@
   "codeowners": [
     "@JurajNyiri"
   ],
-  "version": "5.8.7",
+  "version": "6.0.0",
   "requirements": [
     "pytapo==3.3.37"
   ],

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -14,7 +14,7 @@
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
       },
       "ip": {
         "data": {
@@ -34,13 +34,13 @@
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
       },
       "auth_optional_cloud": {
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
+        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
       },
       "other_options": {
         "data": {
@@ -67,7 +67,7 @@
       "invalid_auth": "Invalid authentication data.\nMake sure you have created your 3rd party account via Tapo app.\nYou can also test if these credentials work via rtsp stream, for example VLC using link\nrtsp://username:password@IP Address:554/stream1",
       "unknown": "Unknown error",
       "connection_failed": "Connection failed",
-      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "cold_storage_path_does_not_exist": "Cold storage path does not exist",
       "camera_requires_admin": "Your camera requires cloud password for control",
       "already_configured": "IP address already configured",
@@ -136,7 +136,7 @@
       "invalid_auth": "Invalid authentication data",
       "unknown": "Unknown error",
       "connection_failed": "Connection failed",
-      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "cold_storage_path_does_not_exist": "Cold storage path does not exist",
       "camera_requires_admin": "Camera requires cloud password for control",
       "incorrect_peak_value": "Incorrect sound detection peak value.",

--- a/custom_components/tapo_control/translations/de.json
+++ b/custom_components/tapo_control/translations/de.json
@@ -20,7 +20,7 @@
         "data": {
           "cloud_password": "Tapo Account Passwort"
         },
-        "description": "Dein Tapo Account Passwort Camera requires your cloud password for control.\nThis is the password you used for your Tapo Cloud account with your email.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
       },
       "other_options": {
         "data": {
@@ -44,7 +44,7 @@
       "invalid_auth": "Invalid authentication data.\nMake sure you have created your 3rd party account via Tapo app.\nYou can also test if these credentials work via rtsp stream, for example VLC using link\nrtsp://username:password@IP Adresse:554/stream1",
       "unknown": "Unbekannter Fehler",
       "connection_failed": "Verbindung fehlgeschlagen",
-      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "camera_requires_admin": "Your camera requires cloud password for control",
       "already_configured": "IP Adresse ist schon konfiguriert",
       "incorrect_peak_value": "Ungültiger Schwellenwert für den Geräuschsensor."
@@ -80,7 +80,7 @@
       "invalid_auth": "Ungültige Anmeldedaten",
       "unknown": "Unbekannter Fehler",
       "connection_failed": "Verbindung fehlgeschlagen",
-      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "camera_requires_admin": "Camera requires cloud password for control",
       "incorrect_peak_value": "Ungültiger Schwellenwert für den Geräuschsensor."
     }

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -14,7 +14,7 @@
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
       },
       "ip": {
         "data": {
@@ -34,13 +34,13 @@
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
       },
       "auth_optional_cloud": {
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
+        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
       },
       "other_options": {
         "data": {
@@ -67,7 +67,7 @@
       "invalid_auth": "Invalid authentication data.\nMake sure you have created your 3rd party account via Tapo app.\nYou can also test if these credentials work via rtsp stream, for example VLC using link\nrtsp://username:password@IP Address:554/stream1",
       "unknown": "Unknown error",
       "connection_failed": "Connection failed",
-      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "cold_storage_path_does_not_exist": "Cold storage path does not exist",
       "camera_requires_admin": "Your camera requires cloud password for control",
       "already_configured": "IP address already configured",
@@ -136,7 +136,7 @@
       "invalid_auth": "Invalid authentication data",
       "unknown": "Unknown error",
       "connection_failed": "Connection failed",
-      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "cold_storage_path_does_not_exist": "Cold storage path does not exist",
       "camera_requires_admin": "Camera requires cloud password for control",
       "incorrect_peak_value": "Incorrect sound detection peak value.",

--- a/custom_components/tapo_control/translations/pt-BR.json
+++ b/custom_components/tapo_control/translations/pt-BR.json
@@ -20,7 +20,7 @@
         "data": {
           "cloud_password": "Senha Cloud"
         },
-        "description": "A câmera precisa da sua senha cloud para controle.\nE-mail não é necessário e toda a comunicação continuará sendo totalmente local."
+        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
       },
       "other_options": {
         "data": {
@@ -41,7 +41,7 @@
       "invalid_auth": "Dados inválidos de autenticação",
       "unknown": "Erro desconhecido",
       "connection_failed": "Conexão falhou",
-      "invalid_auth_cloud": "Senha cloud inválida",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "camera_requires_admin": "Sua câmera precisa de senha cloud para controle",
       "already_configured": "Endereço IP já configurado",
       "incorrect_peak_value": "Valor de pico de detecção de som incorreto."
@@ -74,7 +74,7 @@
       "invalid_auth": "Dados inválidos de autenticação",
       "unknown": "Erro desconhecido",
       "connection_failed": "Conexão falhou",
-      "invalid_auth_cloud": "Senha cloud inválida",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "camera_requires_admin": "Sua câmera precisa de senha cloud para controle",
       "incorrect_peak_value": "Valor de pico de detecção de som incorreto."
     }

--- a/custom_components/tapo_control/translations/ru.json
+++ b/custom_components/tapo_control/translations/ru.json
@@ -14,7 +14,7 @@
         "data": {
           "cloud_password": "Пароль от облака"
         },
-        "description": "Камера требует ваш пароль от облака для управления.\nЭто пароль, который вы использовали с вашей электронной почтой при входе в приложение Tapo.\nПлатная подписка Tapo Care не требуется.\nЕсли вы не использовали один и тот же пароль для облака и для учётной записи камеры, этот пароль не совпадает.\nЭлектронная почта не требуется, и вся коммуникация по-прежнему полностью локальная."
+        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
       },
       "ip": {
         "data": {
@@ -33,7 +33,7 @@
         "data": {
           "cloud_password": "Пароль от облака"
         },
-        "description": "Камера требует ваш пароль от облака для управления.\nЭто пароль, который вы использовали с вашей электронной почтой при входе в приложение Tapo.\nПлатная подписка Tapo Care не требуется.\nЕсли вы не использовали один и тот же пароль для облака и для учётной записи камеры, этот пароль не совпадает.\nЭлектронная почта не требуется, и вся коммуникация по-прежнему полностью локальная."
+        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
       },
       "auth_optional_cloud": {
         "data": {
@@ -66,7 +66,7 @@
       "invalid_auth": "Неверные данные аутентификации.\nУбедитесь, что вы создали учетную запись камеры через приложение Tapo.\nВы можете проверить работоспособность этих учётных данных через поток rtsp, например, используя VLC по ссылке\nrtsp:\/\/username:password@IP Address:554\/stream1",
       "unknown": "Неизвестная ошибка",
       "connection_failed": "Не удалось подключиться",
-      "invalid_auth_cloud": "Неверный пароль от облака.\nУбедитесь, что вы вводите пароль от вашего облачного аккаунта, а НЕ пароль, который вы создали через настройки камеры (если они не одинаковы).\nВам нужно ввести пароль, который вы использовали с вашей электронной почтой при входе в приложение Tapo.",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "camera_requires_admin": "Камера требует пароль от облака для управления",
       "already_configured": "IP-адрес уже настроен",
       "incorrect_peak_value": "Некорректное значение пика обнаружения звука."
@@ -126,7 +126,7 @@
       "invalid_auth": "Ошибка аутентификации",
       "unknown": "Неизвестная ошибка",
       "connection_failed": "Не удалось подключиться",
-      "invalid_auth_cloud": "Неверный пароль от облака.\nУбедитесь, что вы вводите пароль от вашего облачного аккаунта, а НЕ пароль, который вы создали через настройки камеры (если они не одинаковы).\nВам нужно ввести пароль, который вы использовали с вашей электронной почтой при входе в приложение Tapo.",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "camera_requires_admin": "Камера требует пароль от облака для управления",
       "incorrect_peak_value": "Некорректное значение пика обнаружения звука.",
       "incorrect_options_action": "Выбрано некорректное действие"

--- a/custom_components/tapo_control/translations/zh-Hant.json
+++ b/custom_components/tapo_control/translations/zh-Hant.json
@@ -20,7 +20,7 @@
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "攝影機需要您的雲端密碼(cloud password)才能控制.\n不需要Email，所有通訊都是本地進行傳輸."
+        "description": "Camera requires your cloud password for recordings.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nYou can skip this step by leaving password empty and enter password later if you do not need recordings viewing functionality."
       },
       "other_options": {
         "data": {
@@ -41,7 +41,7 @@
       "invalid_auth": "Invalid authentication data",
       "unknown": "未知的錯誤",
       "connection_failed": "連接失敗",
-      "invalid_auth_cloud": "雲端密碼(cloud password)錯誤",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "camera_requires_admin": "攝影機需要您的雲端密碼(cloud password)才能控制",
       "already_configured": "IP 位址已經設定過了",
       "incorrect_peak_value": "聲音檢測峰值設定錯誤"
@@ -74,7 +74,7 @@
       "invalid_auth": "Invalid authentication data",
       "unknown": "未知的錯誤",
       "connection_failed": "連接失敗",
-      "invalid_auth_cloud": "雲端密碼(cloud password)錯誤",
+      "invalid_auth_cloud": "Invalid cloud password.\nMake sure you are entering the password for your cloud account and NOT the password which you created via the camera settings (unless they are the same).\nYou need to enter password which you used with your email when signing into the Tapo app.\n\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).",
       "camera_requires_admin": "攝影機需要您的雲端密碼(cloud password)才能控制",
       "incorrect_peak_value": "聲音檢測峰值設定錯誤."
     }


### PR DESCRIPTION
## Victory for Local Control: TP-Link Enables Third-Party Compatibility

On **November 5, 2023**, I reported a security vulnerability to TP-Link. They addressed the issue, but by **April 2024**, users began reporting that their Tapo cameras had stopped working with this integration ([see issue](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/551#issue-2241778170)).  

Thankfully, a temporary workaround was discovered soon after: disabling the cameras' internet access and performing a factory reset restored full functionality.  

Then, on **May 8, 2024**, I was personally affected by this change. Motivated to find a lasting solution, I developed a [proof-of-concept (POC)](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/551#issuecomment-2111341474) just a week later. Within two days, the POC was polished and [ready for use](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/551#issuecomment-2118381739). This solution worked but required the integration to communicate with the TP-Link cloud temporarily. I reached out to TP-Link to ensure they were comfortable with exposing details of their cloud functionality.  

Throughout this period, I maintained active communication with TP-Link, seeking a mutually agreeable solution. TP-Link proposed a dedicated cloud endpoint for integration but ultimately decided against implementing it. By **October 2024**, my proposed solution was also [declined](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/551#issuecomment-2363817573).  

Finally, the breakthrough came this month: as of **December 2024**, TP-Link has introduced a toggle in the Tapo app that re-enables local communication. This new feature, available on any firmware version and with internet-enabled cameras, allows seamless integration with Home Assistant and other third-party tools implementing the local protocol.  

To activate this feature, simply go to your Tapo App and then click on:  
**Me > Tapo Lab > Third-Party Compatibility > On**.  

This is the best outcome we could have hoped for. It restores full local control, reaffirms TP-Link’s commitment to the open-source community, and ensures continued compatibility with Home Assistant.  

---

### **TL;DR:**  
Cameras are now fully functional online with the latest firmware. Enable **Third-Party Compatibility** in the Tapo app to integrate seamlessly with Home Assistant and other third-party tools.  
