### PR TITLE
Add TapoQuickResponseSelect to handle quick response options

### DIFF
--- a/custom_components/tapo_control/select.py
+++ b/custom_components/tapo_control/select.py
@@ -318,13 +318,7 @@ class TapoWhitelampIntensityLevelSelect(TapoSelectEntity):
 
 class TapoQuickResponseSelect(TapoSelectEntity):
     def __init__(self, entry: dict, hass: HomeAssistant, config_entry):
-        self._attr_options = []
-        self._attr_options_id = []
-        
-        for quick_resp_audio in entry["camData"]["quick_response"]:
-            for key in quick_resp_audio:
-                self._attr_options.append(quick_resp_audio[key]["name"])
-                self._attr_options_id.append(quick_resp_audio[key]["id"])
+        self.populateSelectOptions(entry["camData"])
         
         self._attr_current_option = None
         TapoSelectEntity.__init__(
@@ -336,6 +330,14 @@ class TapoQuickResponseSelect(TapoSelectEntity):
             "mdi:comment-alert",
         )
 
+    def populateSelectOptions(self, camData):
+        self._attr_options = []
+        self._attr_options_id = []
+        for quick_resp_audio in camData["quick_response"]:
+            for key in quick_resp_audio:
+                self._attr_options.append(quick_resp_audio[key]["name"])
+                self._attr_options_id.append(quick_resp_audio[key]["id"])
+
     async def async_update(self) -> None:
         await self._coordinator.async_request_refresh()
 
@@ -343,6 +345,7 @@ class TapoQuickResponseSelect(TapoSelectEntity):
         if not camData:
             self._attr_state = "unavailable"
         else:
+            self.populateSelectOptions(camData)
             self._attr_current_option = None
             self._attr_state = self._attr_current_option
 

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -1380,6 +1380,11 @@ async def getCamData(hass, controller):
 
     camData["updated"] = datetime.datetime.utcnow().timestamp()
 
+    try:
+        camData['quick_response'] = data['getQuickRespList']['quick_resp_audio']
+    except Exception:
+        camData['quick_response'] = None
+
     LOGGER.debug("getCamData - done")
     LOGGER.debug("Processed update data:")
     LOGGER.debug(camData)


### PR DESCRIPTION
This PR adds support for playing pre-recorded sounds on compatible devices (e.g., the D230 doorbell) by allowing users to select a sound for playback.

At this time, adding new sounds is only possible through the official Tapo app.

**Note: This functionality requires [https://github.com/JurajNyiri/pytapo/pull/133](https://github.com/JurajNyiri/pytapo/pull/133) to be accepted and merged, as it provides the required methods.**