### PR TITLE
Fix: incorrect check for RTSP enablement

### DIFF
--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -1374,7 +1374,7 @@ class TapoOptionsFlowHandler(OptionsFlow):
                     and len(password) == 0
                     and len(username) == 0
                 )
-                if (len(password) == 0 or len(username) > 0) and (
+                if (len(password) == 0 or len(username) == 0) and (
                     enable_motion_sensor or enable_time_sync
                 ):
 


### PR DESCRIPTION
Looks like a clear typo.

This prevents me from enabling motion sensor.