### PR TITLE
Fix pt.json

### DIFF
--- a/custom_components/tapo_control/translations/pt.json
+++ b/custom_components/tapo_control/translations/pt.json
@@ -1,7 +1,7 @@
 {
   "title": "Tapo: Controlo de Câmaras",
   "config": {
-    "flow_title": "Tapo: Controlo de Câmaras {nome}",
+    "flow_title": "Tapo: Controlo de Câmaras {name}",
     "step": {
       "ip": {
         "data": {


### PR DESCRIPTION
Fix error in Home Assistant log:
```
Logger: homeassistant.helpers.translation
Source: helpers/translation.py:285

Validation of translation placeholders for localized (pt) string component.tapo_control.config.flow_title failed: ({'nome'} != {'name'})
```