### PR TITLE
add logger info to the manifest

### DIFF
--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -35,5 +35,6 @@
     {
       "hostname": "h[0-9][0-9][0-9]*_*"
     }
-  ]
+  ],
+  "loggers": ["custom_components.tapo_control"]
 }


### PR DESCRIPTION
adding this allows the "Enable debug logging" button to appear on the integration's page.