### PR TITLE
Add #507: Stream, Downloads, Sync on devices without RTSP (hub included)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can enable this setting by navigating to `Home Assistant Settings` -> `Devic
 
 Finally, you can turn on, or off switch entity `switch.*_media_sync`.
 
-**Notice:**: Recordings are deleted after the number of hours you have chosen to synchronize passes, once both the actual recording time and the file modified time is older than the number of hours set.
+**Notice:** Recordings are deleted after the number of hours you have chosen to synchronize passes, once both the actual recording time and the file modified time is older than the number of hours set.
 
 ## Troubleshooting | FAQ
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Custom component - Tapo: Cameras Control - to add Tapo cameras, doorbells and chimes into Home Assistant
 
-⭐ Now also exposing a stream for cameras that have no RTSP or ONVIF capabilities.
+⭐ Now also exposing a stream for devices that have no RTSP or ONVIF capabilities.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This custom component creates:
 
 Doorbells, Cameras:
 
-- Up to 4 camera entities: HD and SD, using RTSP standard or TP-Link proprietary video protocol
+- Up to 4 camera entities: HD and SD, using RTSP standard or TP-Link proprietary video protocol. If you choose to use direct entities, it is recommended to disable `Use Stream from Home Assistant` in options for the best performance and battery life.
 - Binary sensor for motion after the motion is detected for the first time
 - Light entity, if the camera supports a floodlight switch
 - Buttons for Calibrate, Format, Manual Alarm start & stop, Moving the camera, Reboot and syncing time

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Custom component - Tapo: Cameras Control - to add Tapo cameras, doorbells and chimes into Home Assistant
 
+⭐ Now also exposing a stream for cameras that have no RTSP or ONVIF capabilities.
+
 ## Installation
 
 Copy contents of custom_components/tapo_control/ to custom_components/tapo_control/ in your Home Assistant config folder.
@@ -41,7 +43,7 @@ Ensure you have Third Party Compatibility turned on in the official Tapo app on 
 
 ![Image describing how to enable Third-Party Compatibility](img/tapo_third_party.png)
 
-**Note: Version 3.8.103 and later is required.**
+Note: Version 3.8.103 and later is required.
 
 ## Usage
 
@@ -67,7 +69,7 @@ This custom component creates:
 
 Doorbells, Cameras:
 
-- Camera entities, one for HD and one for SD stream
+- Up to 4 camera entities: HD and SD, using RTSP standard or TP-Link proprietary video protocol
 - Binary sensor for motion after the motion is detected for the first time
 - Light entity, if the camera supports a floodlight switch
 - Buttons for Calibrate, Format, Manual Alarm start & stop, Moving the camera, Reboot and syncing time
@@ -125,6 +127,33 @@ Finally, you can turn on, or off switch entity `switch.*_media_sync`.
 
 ## Troubleshooting | FAQ
 
+<details>
+  <summary>Which stream to use?</summary>
+
+This integration exposes 4 different camera entities:
+
+- HD Stream
+- SD Stream
+- HD Stream (Direct)
+- SD Stream (Direct)
+
+Direct streams use proprietary TP-Link streaming protocol. Non-direct ones use standard RTSP protocol.
+
+### Why use the Direct streams?
+
+1. If you have a device which does not have RTSP functionality, it is the only way. This includes battery devices, solar devices, as well as devices working through a hub.
+2. If you have used up [all your RTSP streams](https://www.tp-link.com/cz/support/faq/2742/) and/or your RTSP streams are unstable in Home Assistant.
+3. Direct streams are _extremely_ fast to load and have less than a half a second delay in stream* (_*make sure to DISABLE `Use Stream from Home Assistant (restart required)` in integration options for the fastest experience_). Under the hood, the new streams are a binary stream of data "straight to your browser", with no unnecessary translations or overhead.
+
+### Why not use the Direct streams?
+
+If you have an option to use RTSP, it is recommended to stick with RTSP streams.
+
+1. Direct streams take a bit more CPU resources since the device running this integration is now handling the binary stream directly, instead of camera exposing a standardized RTSP stream.
+2. Direct streams cannot be used with webrtc card, or go2rtc.
+3. RTSP streams are very fast with almost no delay using the [webrtc](https://github.com/AlexxIT/WebRTC) Home Assistant camera card
+
+</details>
 <details>
   <summary>Binary sensor for motion doesn't show up or work</summary>
 
@@ -259,15 +288,12 @@ Users reported full functionality with following Tapo Cameras, Doorbells and Chi
 - C530WS
 - C720
 - D100C
-
-The integration _should_ work with any other non-battery Tapo Camera based devices and chimes.
-
-Battery cameras controlled via HUB are working only for control:
-
 - D230
 - C420
 - C420S2
 - TC85
+
+The integration _should_ work with any other Tapo Camera based devices and chimes.
 
 If you had success with some other model, please report it via a new issue.
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -81,8 +81,8 @@ from .utils import (
     getRecordings,
     scheduleAll,
 )
-from .pytapo import Tapo
-from .pytapo.version import PYTAPO_VERSION
+from pytapo import Tapo
+from pytapo.version import PYTAPO_VERSION
 
 from homeassistant.helpers.event import async_track_time_interval
 from datetime import timedelta

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -786,9 +786,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 ts - hass.data[DOMAIN][entry.entry_id]["lastMediaCleanup"]
                 > MEDIA_CLEANUP_PERIOD
             ):
-                # await mediaCleanup(hass, entry)
-                LOGGER.warning("TODOOOOO")
-                pass
+                LOGGER.warning(
+                    "Initiating media cleanup for "
+                    + hass.data[DOMAIN][entry.entry_id]["name"]
+                    + "..."
+                )
+                await mediaCleanup(hass, entry, hass.data[DOMAIN][entry.entry_id])
+            if hass.data[DOMAIN][entry.entry_id]["isParent"]:
+                for child in hass.data[DOMAIN][entry.entry_id]["childDevices"]:
+                    if ts - child["lastMediaCleanup"] > MEDIA_CLEANUP_PERIOD:
+                        LOGGER.warning(
+                            "Initiating media cleanup for " + child["name"] + "..."
+                        )
+                        await mediaCleanup(hass, entry, child)
 
             if (
                 hass.is_running

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -787,7 +787,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 ts - hass.data[DOMAIN][entry.entry_id]["lastMediaCleanup"]
                 > MEDIA_CLEANUP_PERIOD
             ):
-                LOGGER.warning(
+                LOGGER.debug(
                     "Initiating media cleanup for "
                     + hass.data[DOMAIN][entry.entry_id]["name"]
                     + "..."
@@ -796,7 +796,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if hass.data[DOMAIN][entry.entry_id]["isParent"]:
                 for child in hass.data[DOMAIN][entry.entry_id]["childDevices"]:
                     if ts - child["lastMediaCleanup"] > MEDIA_CLEANUP_PERIOD:
-                        LOGGER.warning(
+                        LOGGER.debug(
                             "Initiating media cleanup for " + child["name"] + "..."
                         )
                         await mediaCleanup(hass, entry, child)
@@ -1024,17 +1024,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         # todo move to utils
         async def mediaSync(now, entry, device):
-            LOGGER.warning("mediaSync")
+            LOGGER.debug("mediaSync")
             device["mediaSyncRanOnce"] = True
             enableMediaSync = device[ENABLE_MEDIA_SYNC]
             mediaSyncHours = entry.data.get(MEDIA_SYNC_HOURS)
-            LOGGER.warning("mediaSync - 2")
+            LOGGER.debug("mediaSync - 2")
 
             if mediaSyncHours == "":
                 mediaSyncTime = False
             else:
                 mediaSyncTime = (int(mediaSyncHours) * 60 * 60) + timeCorrection
-            LOGGER.warning("mediaSync - 3")
+            LOGGER.debug("mediaSync - 3")
             if (
                 enableMediaSync
                 and entry.entry_id in hass.data[DOMAIN]
@@ -1043,22 +1043,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 and device["isDownloadingStream"]
                 is False  # prevent breaking user manual upload
             ):
-                LOGGER.warning("Running media sync for " + device["name"] + "...")
+                LOGGER.debug("Running media sync for " + device["name"] + "...")
                 device["runningMediaSync"] = True
                 try:
                     tapoController: Tapo = device["controller"]
-                    LOGGER.warning("getRecordingsList -1")
+                    LOGGER.debug("getRecordingsList -1")
                     recordingsList = await hass.async_add_executor_job(
                         tapoController.getRecordingsList
                     )
-                    LOGGER.warning("getRecordingsList -2")
+                    LOGGER.debug("getRecordingsList -2")
 
                     ts = datetime.datetime.utcnow().timestamp()
                     for searchResult in recordingsList:
                         for key in searchResult:
-                            LOGGER.warning("inside for - 1")
+                            LOGGER.debug("inside for - 1")
                             enableMediaSync = device[ENABLE_MEDIA_SYNC]
-                            LOGGER.warning("inside for - 2")
+                            LOGGER.debug("inside for - 2")
                             if enableMediaSync and (
                                 (mediaSyncTime is False)
                                 or (
@@ -1073,14 +1073,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                     )
                                 )
                             ):
-                                LOGGER.warning("getRecordings -1")
+                                LOGGER.debug("getRecordings -1")
                                 recordingsForDay = await getRecordings(
                                     hass,
                                     device,
                                     tapoController,
                                     searchResult[key]["date"],
                                 )
-                                LOGGER.warning("getRecordings -2")
+                                LOGGER.debug("getRecordings -2")
                                 totalRecordingsToDownload = 0
                                 for recording in recordingsForDay:
                                     for recordingKey in recording:
@@ -1100,7 +1100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                                     ENABLE_MEDIA_SYNC
                                                 ]
                                                 if enableMediaSync:
-                                                    LOGGER.warning("getRecording -1")
+                                                    LOGGER.debug("getRecording -1")
                                                     await getRecording(
                                                         hass,
                                                         tapoController,
@@ -1116,9 +1116,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                                         recordingCount,
                                                         totalRecordingsToDownload,
                                                     )
-                                                    LOGGER.warning("getRecording -2")
+                                                    LOGGER.debug("getRecording -2")
                                                 else:
-                                                    LOGGER.warning(
+                                                    LOGGER.debug(
                                                         f"Media sync disabled (inside getRecording): {enableMediaSync}"
                                                     )
                                             except Unresolvable as err:
@@ -1133,7 +1133,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                                 device["runningMediaSync"] = False
                                                 LOGGER.error(err)
                             else:
-                                LOGGER.warning(
+                                LOGGER.debug(
                                     f"Media sync ignoring {searchResult[key]["date"]}. Media sync: {enableMediaSync}."
                                 )
                 except Exception as err:
@@ -1141,7 +1141,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 LOGGER.debug("runningMediaSync -false")
                 device["runningMediaSync"] = False
             else:
-                LOGGER.warning(
+                LOGGER.debug(
                     f"Media sync for {device["name"]} disabled (inside mediaSync): {enableMediaSync}"
                 )
 

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -80,8 +80,8 @@ from .utils import (
     findMedia,
     getRecordings,
 )
-from pytapo import Tapo
-from pytapo.version import PYTAPO_VERSION
+from .pytapo import Tapo
+from .pytapo.version import PYTAPO_VERSION
 
 from homeassistant.helpers.event import async_track_time_interval
 from datetime import timedelta

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1079,7 +1079,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                             ):
                                 LOGGER.debug("getRecordings -1")
                                 recordingsForDay = await getRecordings(
-                                    hass, entry.entry_id, searchResult[key]["date"]
+                                    hass,
+                                    entry.entry_id,
+                                    tapoController,
+                                    searchResult[key]["date"],
                                 )
                                 LOGGER.debug("getRecordings -2")
                                 totalRecordingsToDownload = 0

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1,11 +1,11 @@
 import datetime
 import hashlib
 import asyncio
+from aiohttp import ClientError
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.ffmpeg import CONF_EXTRA_ARGUMENTS
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.device_registry import async_get as device_registry_async_get
 from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_USERNAME,
@@ -397,7 +397,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             async with asyncio.timeout(3):
                 await hass.data[DOMAIN][entry.entry_id]["events"].async_stop()
-        except TimeoutError:
+        except (asyncio.TimeoutError, ClientError):
             LOGGER.warning(
                 "Timed out waiting for onvif connection to close, proceeding."
             )

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1119,14 +1119,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                     )
                                 )
                             ):
-                                LOGGER.debug("getRecordings -1")
+                                LOGGER.warning("getRecordings -1")
                                 recordingsForDay = await getRecordings(
                                     hass,
-                                    entry.entry_id,
+                                    hass.data[DOMAIN][entry.entry_id],
                                     tapoController,
                                     searchResult[key]["date"],
                                 )
-                                LOGGER.debug("getRecordings -2")
+                                LOGGER.warning("getRecordings -2")
                                 totalRecordingsToDownload = 0
                                 for recording in recordingsForDay:
                                     for recordingKey in recording:
@@ -1147,7 +1147,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                                 ][ENABLE_MEDIA_SYNC]
                                                 if enableMediaSync:
                                                     LOGGER.debug("getRecording -1")
-                                                    await getRecording(
+                                                    await getRecording(  # TODO modify to work with child
                                                         hass,
                                                         tapoController,
                                                         entry.entry_id,

--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -919,12 +919,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         if tapoController.isKLAP is False:
             LOGGER.debug("Controller is not KLAP device.")
-            if camData["childDevices"] is False or camData["childDevices"] is None:
-                LOGGER.debug("Setting up camera entities.")
-                await hass.async_create_task(
-                    hass.config_entries.async_forward_entry_setups(entry, ["camera"])
-                )
-            else:
+            if not (
+                camData["childDevices"] is False or camData["childDevices"] is None
+            ):
                 LOGGER.debug("Device is a parent.")
                 hass.data[DOMAIN][entry.entry_id]["isParent"] = True
                 for childDevice in camData["childDevices"]["child_device_list"]:
@@ -973,6 +970,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                             "isParent": False,
                         }
                     )
+            LOGGER.debug("Setting up camera entities.")
+            await hass.async_create_task(
+                hass.config_entries.async_forward_entry_setups(entry, ["camera"])
+            )
 
         LOGGER.debug("Setting up entities.")
         await hass.async_create_task(

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
         entry["entities"].append({"entity": sdStream, "entry": entry})
         async_add_entities([hdStream, sdStream])
     elif True:  # TODO REFACTOR ME
-        hdStream = TapoCamEntity(hass, config_entry, entry, True)
+        hdStream = TapoDirectCamEntity(hass, config_entry, entry, True)
         entry["entities"].append({"entity": hdStream, "entry": entry})
         async_add_entities([hdStream])
 
@@ -98,27 +98,16 @@ class TapoCamEntity(Camera):
         self._attr_should_poll = True
         self._is_cam_entity = True
         self._is_noise_sensor = False
-        self._HAstream: Stream | None = None
-
-        self._streamer: Streamer | None = None
-        self._stream_fd: int | None = None
-        self._stream_task: asyncio.Task | None = None
 
         self.updateTapo(entry["camData"])
-
-    def debugLog(self, msg):
-        LOGGER.debug(msg)
 
     async def async_added_to_hass(self) -> None:
         self._enabled = True
         await super().async_added_to_hass()
 
     async def async_will_remove_from_hass(self) -> None:
-        if self._streamer:
-            await self._streamer.stop()
-        if self._stream_task:
-            self._stream_task.cancel()
         self._enabled = False
+        await super().async_will_remove_from_hass()
 
     @property
     def supported_features(self):
@@ -162,181 +151,14 @@ class TapoCamEntity(Camera):
     def model(self):
         return self._attr_extra_state_attributes["device_model"]
 
-    async def async_camera_image(
-        self, width: int | None = None, height: int | None = None
-    ):
-        """Return a single JPEG made from a fresh in‑memory preview."""
-        # ── 1.  Spin‑up a short‑lived Streamer in pipe mode ────────────────
-        streamer = Streamer(
-            self._controller,
-            includeAudio=False,
-        )
-        info = await streamer.start()
-        fd = info["read_fd"]
-        os.set_inheritable(fd, True)
-
-        # ── 2.  Run FFmpeg to capture exactly one frame ────────────────────
-        ff_cmd = [
-            self._ffmpeg.binary,
-            "-loglevel",
-            "error",
-            "-probesize",
-            "256k",
-            "-analyzeduration",
-            "500000",
-            "-i",
-            f"pipe:{fd}",
-            "-frames:v",
-            "1",
-            "-f",
-            "image2",
-            "-q:v",
-            "2",
-            "pipe:1",
-        ]
-        proc = await asyncio.create_subprocess_exec(
-            *ff_cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-            pass_fds=(fd,),
-        )
-        jpeg, _ = await proc.communicate()
-
-        # ── 3.  Clean‑up ───────────────────────────────────────────────────
-        await streamer.stop()  # stops internal tasks + ffmpeg
-        info["streamProcess"].cancel()  # just in case
-        return jpeg
-
-    async def handle_async_mjpeg_stream(self, request):
-        """Serve a live MJPEG preview built on‑the‑fly from the Tapo TS pipe."""
-
-        LOGGER.warning("MJPEG ⟶ request")
-
-        # ── 1.  Start a *short‑lived* Streamer instance in pipe‑only mode ──────
-        streamer = Streamer(
-            self._controller,
-            includeAudio=False,  # video only for MJPEG
-        )
-        info = await streamer.start()
-        fd: int = info["read_fd"]
-        os.set_inheritable(fd, True)
-        LOGGER.warning("MJPEG ⟶ using pipe fd %s", fd)
-
-        # ── 2.  Spawn FFmpeg: TS → MJPEG (multipart) ───────────────────────────
-        ff_cmd = [
-            self._ffmpeg.binary,
-            "-loglevel",
-            "info",  # see what happens, but not too chatty
-            "-hide_banner",
-            "-probesize",
-            "256k",
-            "-analyzeduration",
-            "500000",  # 0.5 s is plenty for a TS preview
-            "-i",
-            f"pipe:{fd}",  # INPUT: live TS from the Streamer
-            "-c:v",
-            "mjpeg",
-            "-q:v",
-            "5",  # 2‑31 (lower = better quality)
-            "-f",
-            "mpjpeg",  # ***multipart*** MJPEG for browsers
-            "pipe:1",  # OUTPUT to stdout
-        ]
-        LOGGER.warning("MJPEG ⟶ ffmpeg cmd: %s", " ".join(ff_cmd))
-
-        proc = await asyncio.create_subprocess_exec(
-            *ff_cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            pass_fds=(fd,),
-        )
-        LOGGER.warning("MJPEG ⟶ ffmpeg PID %s", proc.pid)
-
-        # mirror FFmpeg stderr into the HA log (useful for debugging)
-        asyncio.create_task(self._log_stream(proc.stderr, prefix="MJPEG ffmpeg"))
-
-        try:
-            # proxy stdout (multipart MJPEG) directly to the client
-            return await async_aiohttp_proxy_stream(
-                self.hass,
-                request,
-                proc.stdout,
-                self._ffmpeg.ffmpeg_stream_content_type,  # correct MIME header
-            )
-        finally:
-            LOGGER.warning("MJPEG ⟶ shutting ffmpeg / streamer")
-            if proc.returncode is None:
-                proc.kill()
-                await proc.wait()
-            await streamer.stop()  # terminates the internal tasks
-            info["streamProcess"].cancel()  # extra safety – no dangling task
-
-    async def _log_stream(self, stream: asyncio.StreamReader, *, prefix=""):
-        """Helper: mirror every stderr line into HA log."""
-        async for line in stream:
-            LOGGER.warning("%s: %s", prefix, line.decode().rstrip())
-
     async def async_update(self) -> None:
         await self._coordinator.async_request_refresh()
 
-    async def _ensure_av_pipe(self, newStream=False) -> None:
-        LOGGER.warning("_ensure_av_pipe() called")
-
-        if self._streamer and self._streamer.running and not newStream:
-            LOGGER.warning("_ensure_av_pipe → already running (fd=%s)", self._stream_fd)
-            return
-
-        if self._streamer:
-            LOGGER.warning("_ensure_av_pipe → stopping previous Streamer")
-            try:
-                await self._streamer.stop()
-                if self._stream_task:
-                    self._stream_task.cancel()
-            except ConnectionRefusedError as err:
-                LOGGER.warning(err)
-                pass
-
-        LOGGER.warning("_ensure_av_pipe → launching NEW Streamer")
-        self._streamer = Streamer(
-            self._controller,
-            includeAudio=False,
-        )
-        info = await self._streamer.start()
-
-        self._stream_fd: int = info["read_fd"]
-
-        if self._HAstream is not None:
-            newSource = await self.stream_source()
-            self._HAstream.update_source(newSource)
-
-        os.set_inheritable(self._stream_fd, True)
-        self._stream_task = info["streamProcess"]
-
-        LOGGER.warning(
-            "_ensure_av_pipe → ready (fd=%s, task=%s)",
-            self._stream_fd,
-            self._stream_task,
-        )
-
-    async def stream_source(self) -> str | None:
-        source = f"pipe:{self._stream_fd}"
-        LOGGER.warning("stream_source → returning  %s", source)
-        return source
-
     async def async_create_stream(self) -> Stream | None:
-        await self._ensure_av_pipe()
-        self._HAstream = await super().async_create_stream()
-        self._HAstream.set_update_callback(self._on_stream_state)
-
-        return self._HAstream
-
-    def _on_stream_state(self):
-        if not self._HAstream.available:
-            LOGGER.warning("%s: HA stream unavailable – restarting", self.entity_id)
-            asyncio.create_task(self._ensure_av_pipe(newStream=True))
+        return await super().async_create_stream()
 
     def updateTapo(self, camData):
-        LOGGER.debug("updateTapo - camera")
+        LOGGER.warning("updateTapo - camera")
         if not camData:
             self._attr_state = STATE_UNAVAILABLE
         else:
@@ -455,3 +277,199 @@ class TapoCamEntity(Camera):
                 await self._coordinator.async_request_refresh()
             else:
                 LOGGER.error("Preset " + preset + " does not exist.")
+
+
+class TapoDirectCamEntity(TapoCamEntity):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: dict,
+        entry: dict,
+        HDStream: boolean,
+    ):
+        super().__init__(hass, config_entry, entry, HDStream)
+
+        self._HAstream: Stream | None = None
+        self._streamer: Streamer | None = None
+        self._stream_fd: int | None = None
+        self._stream_task: asyncio.Task | None = None
+
+    def debugLog(self, msg):
+        LOGGER.debug(msg)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._streamer:
+            await self._streamer.stop()
+        if self._stream_task:
+            self._stream_task.cancel()
+        await super().async_will_remove_from_hass()
+
+    async def async_camera_image(
+        self, width: int | None = None, height: int | None = None
+    ):
+        """Return a single JPEG made from a fresh in‑memory preview."""
+        # ── 1.  Spin‑up a short‑lived Streamer in pipe mode ────────────────
+        streamer = Streamer(
+            self._controller,
+            includeAudio=False,
+        )
+        info = await streamer.start()
+        fd = info["read_fd"]
+        os.set_inheritable(fd, True)
+
+        # ── 2.  Run FFmpeg to capture exactly one frame ────────────────────
+        ff_cmd = [
+            self._ffmpeg.binary,
+            "-loglevel",
+            "error",
+            "-probesize",
+            "256k",
+            "-analyzeduration",
+            "500000",
+            "-i",
+            f"pipe:{fd}",
+            "-frames:v",
+            "1",
+            "-f",
+            "image2",
+            "-q:v",
+            "2",
+            "pipe:1",
+        ]
+        proc = await asyncio.create_subprocess_exec(
+            *ff_cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            pass_fds=(fd,),
+        )
+        jpeg, _ = await proc.communicate()
+
+        # ── 3.  Clean‑up ───────────────────────────────────────────────────
+        await streamer.stop()  # stops internal tasks + ffmpeg
+        info["streamProcess"].cancel()  # just in case
+        return jpeg
+
+    async def handle_async_mjpeg_stream(self, request):
+        """Serve a live MJPEG preview built on‑the‑fly from the Tapo TS pipe."""
+
+        LOGGER.warning("MJPEG ⟶ request")
+
+        # ── 1.  Start a *short‑lived* Streamer instance in pipe‑only mode ──────
+        streamer = Streamer(
+            self._controller,
+            includeAudio=False,  # video only for MJPEG
+        )
+        info = await streamer.start()
+        fd: int = info["read_fd"]
+        os.set_inheritable(fd, True)
+        LOGGER.warning("MJPEG ⟶ using pipe fd %s", fd)
+
+        # ── 2.  Spawn FFmpeg: TS → MJPEG (multipart) ───────────────────────────
+        ff_cmd = [
+            self._ffmpeg.binary,
+            "-loglevel",
+            "info",  # see what happens, but not too chatty
+            "-hide_banner",
+            "-probesize",
+            "256k",
+            "-analyzeduration",
+            "500000",  # 0.5 s is plenty for a TS preview
+            "-i",
+            f"pipe:{fd}",  # INPUT: live TS from the Streamer
+            "-c:v",
+            "mjpeg",
+            "-q:v",
+            "5",  # 2‑31 (lower = better quality)
+            "-f",
+            "mpjpeg",  # ***multipart*** MJPEG for browsers
+            "pipe:1",  # OUTPUT to stdout
+        ]
+        LOGGER.warning("MJPEG ⟶ ffmpeg cmd: %s", " ".join(ff_cmd))
+
+        proc = await asyncio.create_subprocess_exec(
+            *ff_cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            pass_fds=(fd,),
+        )
+        LOGGER.warning("MJPEG ⟶ ffmpeg PID %s", proc.pid)
+
+        # mirror FFmpeg stderr into the HA log (useful for debugging)
+        asyncio.create_task(self._log_stream(proc.stderr, prefix="MJPEG ffmpeg"))
+
+        try:
+            # proxy stdout (multipart MJPEG) directly to the client
+            return await async_aiohttp_proxy_stream(
+                self.hass,
+                request,
+                proc.stdout,
+                self._ffmpeg.ffmpeg_stream_content_type,  # correct MIME header
+            )
+        finally:
+            LOGGER.warning("MJPEG ⟶ shutting ffmpeg / streamer")
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+            await streamer.stop()  # terminates the internal tasks
+            info["streamProcess"].cancel()  # extra safety – no dangling task
+
+    async def _log_stream(self, stream: asyncio.StreamReader, *, prefix=""):
+        """Helper: mirror every stderr line into HA log."""
+        async for line in stream:
+            LOGGER.warning("%s: %s", prefix, line.decode().rstrip())
+
+    async def _ensure_av_pipe(self, newStream=False) -> None:
+        LOGGER.warning("_ensure_av_pipe() called")
+
+        if self._streamer and self._streamer.running and not newStream:
+            LOGGER.warning("_ensure_av_pipe → already running (fd=%s)", self._stream_fd)
+            return
+
+        if self._streamer:
+            LOGGER.warning("_ensure_av_pipe → stopping previous Streamer")
+            try:
+                await self._streamer.stop()
+                if self._stream_task:
+                    self._stream_task.cancel()
+            except ConnectionRefusedError as err:
+                LOGGER.warning(err)
+                pass
+
+        LOGGER.warning("_ensure_av_pipe → launching NEW Streamer")
+        self._streamer = Streamer(
+            self._controller,
+            includeAudio=False,
+        )
+        info = await self._streamer.start()
+
+        self._stream_fd: int = info["read_fd"]
+
+        if self._HAstream is not None:
+            newSource = await self.stream_source()
+            self._HAstream.update_source(newSource)
+
+        os.set_inheritable(self._stream_fd, True)
+        self._stream_task = info["streamProcess"]
+
+        LOGGER.warning(
+            "_ensure_av_pipe → ready (fd=%s, task=%s)",
+            self._stream_fd,
+            self._stream_task,
+        )
+
+    async def stream_source(self) -> str | None:
+        source = f"pipe:{self._stream_fd}"
+        LOGGER.warning("stream_source → returning  %s", source)
+        return source
+
+    async def async_create_stream(self) -> Stream | None:
+        await self._ensure_av_pipe()
+        self._HAstream = await super().async_create_stream()
+        self._HAstream.set_update_callback(self._on_stream_state)
+
+        return self._HAstream
+
+    def _on_stream_state(self):
+        if not self._HAstream.available:
+            LOGGER.warning("%s: HA stream unavailable – restarting", self.entity_id)
+            asyncio.create_task(self._ensure_av_pipe(newStream=True))

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -105,25 +105,6 @@ class TapoCamEntity(Camera):
     def debugLog(self, msg):
         LOGGER.debug(msg)
 
-    async def _ensure_pipe(self):
-        LOGGER.warning("_ensure_pipe")
-        if self._streamer and self._streamer.running:
-            LOGGER.warning("running")
-            return
-
-        self._streamer = Streamer(
-            self._controller,
-            callbackFunction=self.debugLog,
-            mode="pipe",  # ← switch to pipe
-            outputDirectory="/config/videos/",
-            includeAudio=True,  # or follow user option
-        )
-        info = await self._streamer.start()
-        self._stream_fd = info["read_fd"]
-        LOGGER.warning("Creating " + str(self._stream_fd))
-        os.set_inheritable(self._stream_fd, True)  # good practice
-        self._stream_task = info["streamProcess"]
-
     async def async_added_to_hass(self) -> None:
         self._enabled = True
 
@@ -183,8 +164,6 @@ class TapoCamEntity(Camera):
         # ── 1.  Spin‑up a short‑lived Streamer in pipe mode ────────────────
         streamer = Streamer(
             self._controller,
-            callbackFunction=lambda *_: None,
-            mode="pipe",
             includeAudio=False,
         )
         info = await streamer.start()
@@ -231,8 +210,6 @@ class TapoCamEntity(Camera):
         # ── 1.  Start a *short‑lived* Streamer instance in pipe‑only mode ──────
         streamer = Streamer(
             self._controller,
-            callbackFunction=lambda *_: None,  # silence low‑level spam
-            mode="pipe",
             includeAudio=False,  # video only for MJPEG
         )
         info = await streamer.start()
@@ -319,8 +296,6 @@ class TapoCamEntity(Camera):
         LOGGER.warning("_ensure_av_pipe → launching NEW Streamer (audio=on)")
         self._streamer = Streamer(
             self._controller,
-            callbackFunction=lambda *_: None,  # keep low‑level logs quiet
-            mode="pipe",
             includeAudio=False,  # *** A/V ***
         )
         info = await self._streamer.start()

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -55,6 +55,7 @@ async def async_setup_entry(
     if (
         len(config_entry.data[CONF_USERNAME]) > 0
         and len(config_entry.data[CONF_PASSWORD]) > 0
+        and False  # TODO REFACTOR ME
     ):
         hdStream = TapoCamEntity(hass, config_entry, entry, True)
         sdStream = TapoCamEntity(hass, config_entry, entry, False)
@@ -62,6 +63,10 @@ async def async_setup_entry(
         entry["entities"].append({"entity": hdStream, "entry": entry})
         entry["entities"].append({"entity": sdStream, "entry": entry})
         async_add_entities([hdStream, sdStream])
+    elif True:  # TODO REFACTOR ME
+        hdStream = TapoCamEntity(hass, config_entry, entry, True)
+        entry["entities"].append({"entity": hdStream, "entry": entry})
+        async_add_entities([hdStream])
 
 
 class TapoCamEntity(Camera):

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -228,7 +228,8 @@ class TapoCamEntity(Camera):
     # --------------------------------------------------------------------------- #
     async def handle_async_mjpeg_stream(self, request):
         """Serve MJPEG generated from the live in‑memory pipe."""
-        LOGGER.warning("MJPEG ⟶ request")
+        LOGGER.warning("TODO")
+        raise Exception("temp TODO")
 
         # 1 ── make sure the Streamer (pipe backend) is running
         await self._ensure_pipe()

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -129,7 +129,7 @@ class TapoCamEntity(Camera):
 
     async def async_will_remove_from_hass(self) -> None:
         if self._streamer:
-            await self._streamer.stop_hls()
+            await self._streamer.stop()
         if self._stream_task:
             self._stream_task.cancel()
         self._enabled = False
@@ -219,7 +219,7 @@ class TapoCamEntity(Camera):
         jpeg, _ = await proc.communicate()
 
         # ── 3.  Clean‑up ───────────────────────────────────────────────────
-        await streamer.stop_hls()  # stops internal tasks + ffmpeg
+        await streamer.stop()  # stops internal tasks + ffmpeg
         info["streamProcess"].cancel()  # just in case
         return jpeg
 
@@ -286,7 +286,7 @@ class TapoCamEntity(Camera):
             if proc.returncode is None:
                 proc.kill()
                 await proc.wait()
-            await streamer.stop_hls()  # terminates the internal tasks
+            await streamer.stop()  # terminates the internal tasks
             info["streamProcess"].cancel()  # extra safety – no dangling task
 
     async def _log_stream(self, stream: asyncio.StreamReader, *, prefix=""):
@@ -311,7 +311,7 @@ class TapoCamEntity(Camera):
         # Otherwise tear down anything old (e.g. video‑only preview Streamer)
         if self._streamer:
             LOGGER.warning("_ensure_av_pipe → stopping previous Streamer")
-            await self._streamer.stop_hls()
+            await self._streamer.stop()
             if self._stream_task:
                 self._stream_task.cancel()
 

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -453,7 +453,7 @@ class TapoDirectCamEntity(TapoCamEntity):
                 self._ffmpeg.ffmpeg_stream_content_type,
             )
         finally:
-            LOGGER.warning("Direct MJPEG: shutting ffmpeg / streamer")
+            LOGGER.debug("Direct MJPEG: shutting ffmpeg / streamer")
             if proc.returncode is None:
                 proc.kill()
                 await proc.wait()

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -69,15 +69,16 @@ async def async_setup_entry(
             hasRTSPEntities = True
             async_add_entities([hdStream, sdStream])
 
-        directStreamHD = TapoDirectCamEntity(
-            hass, config_entry, entry, True, enabledByDefault=not hasRTSPEntities
-        )
-        directStreamSD = TapoDirectCamEntity(
-            hass, config_entry, entry, False, enabledByDefault=False
-        )
-        entry["entities"].append({"entity": directStreamHD, "entry": entry})
-        entry["entities"].append({"entity": directStreamSD, "entry": entry})
-        async_add_entities([directStreamHD, directStreamSD])
+        if not entry["isParent"]:
+            directStreamHD = TapoDirectCamEntity(
+                hass, config_entry, entry, True, enabledByDefault=not hasRTSPEntities
+            )
+            directStreamSD = TapoDirectCamEntity(
+                hass, config_entry, entry, False, enabledByDefault=False
+            )
+            entry["entities"].append({"entity": directStreamHD, "entry": entry})
+            entry["entities"].append({"entity": directStreamSD, "entry": entry})
+            async_add_entities([directStreamHD, directStreamSD])
 
     await setupEntities(entry)
     for childDevice in entry["childDevices"]:

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -69,11 +69,15 @@ async def async_setup_entry(
         hasRTSPEntities = True
         async_add_entities([hdStream, sdStream])
 
-    directStream = TapoDirectCamEntity(
+    directStreamHD = TapoDirectCamEntity(
         hass, config_entry, entry, True, enabledByDefault=not hasRTSPEntities
     )
-    entry["entities"].append({"entity": directStream, "entry": entry})
-    async_add_entities([directStream])
+    directStreamSD = TapoDirectCamEntity(
+        hass, config_entry, entry, False, enabledByDefault=False
+    )
+    entry["entities"].append({"entity": directStreamHD, "entry": entry})
+    entry["entities"].append({"entity": directStreamSD, "entry": entry})
+    async_add_entities([directStreamHD, directStreamSD])
 
 
 class TapoCamEntity(Camera):
@@ -344,6 +348,11 @@ class TapoDirectCamEntity(TapoCamEntity):
     ):
         super().__init__(hass, config_entry, entry, HDStream, True)
 
+        if HDStream:
+            self._directQuality = "HD"
+        else:
+            self._directQuality = "VGA"
+
         self._HAstream: Stream | None = None
         self._streamer: Streamer | None = None
         self._stream_fd: int | None = None
@@ -368,6 +377,7 @@ class TapoDirectCamEntity(TapoCamEntity):
         streamer = Streamer(
             self._controller,
             includeAudio=False,
+            quality=self._directQuality,
         )
         info = await streamer.start()
         fd = info["read_fd"]
@@ -408,6 +418,7 @@ class TapoDirectCamEntity(TapoCamEntity):
         streamer = Streamer(
             self._controller,
             includeAudio=False,
+            quality=self._directQuality,
         )
         info = await streamer.start()
         fd: int = info["read_fd"]
@@ -485,6 +496,7 @@ class TapoDirectCamEntity(TapoCamEntity):
         self._streamer = Streamer(
             self._controller,
             includeAudio=False,
+            quality=self._directQuality,
         )
         info = await self._streamer.start()
 

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -359,7 +359,6 @@ class TapoDirectCamEntity(TapoCamEntity):
         self._stream_task: asyncio.Task | None = None
         self._enabled_by_default = enabledByDefault
 
-    # Disable entity by default if RTSP is enabled
     @property
     def entity_registry_enabled_default(self) -> bool:
         return self._enabled_by_default

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -4,7 +4,7 @@ import os
 from haffmpeg.camera import CameraMjpeg
 from haffmpeg.tools import IMAGE_JPEG, ImageFrame
 from typing import Callable
-from .pytapo.media_stream.streamer import Streamer
+from pytapo.media_stream.streamer import Streamer
 
 from homeassistant.const import STATE_UNAVAILABLE, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant

--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -819,20 +819,18 @@ class FlowHandler(ConfigFlow):
                         self.tapoHost,
                     )
                     cloud_password = user_input[CLOUD_PASSWORD]
-                    tapoController = await self.hass.async_add_executor_job(
+                    await self.hass.async_add_executor_job(
                         registerController,
                         self.tapoHost,
                         self.tapoControlPort,
                         "admin",
                         cloud_password,
                     )
-                    camData = await getCamData(self.hass, tapoController)
                     LOGGER.debug(
                         "[ADD DEVICE][%s] Cloud password works for control.",
                         self.tapoHost,
                     )
                     self.tapoCloudPassword = cloud_password
-                    self.reportedIPAddress = getIP(camData)
                     return await self.async_step_other_options()
                 except Exception as e:
                     if "Failed to establish a new connection" in str(e):
@@ -950,7 +948,7 @@ class FlowHandler(ConfigFlow):
                             "[ADD DEVICE][%s] Testing control of camera using Camera Account.",
                             host,
                         )
-                        await self.hass.async_add_executor_job(
+                        tapoController = await self.hass.async_add_executor_job(
                             registerController,
                             host,
                             controlPort,
@@ -961,6 +959,9 @@ class FlowHandler(ConfigFlow):
                             "[ADD DEVICE][%s] Camera Account works for control.",
                             host,
                         )
+
+                        camData = await getCamData(self.hass, tapoController)
+                        self.reportedIPAddress = getIP(camData)
                     except Exception as e:
                         if str(e) == "Invalid authentication data":
                             LOGGER.debug(

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from homeassistant.helpers import config_validation as cv
 
 CONTROL_PORT = "control_port"
-PYTAPO_REQUIRED_VERSION = "3.3.46"
+PYTAPO_REQUIRED_VERSION = "3.3.49"
 DOMAIN = "tapo_control"
 BRAND = "TP-Link"
 ALARM_MODE = "alarm_mode"

--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -6,9 +6,9 @@
   "codeowners": [
     "@JurajNyiri"
   ],
-  "version": "6.1.9",
+  "version": "7.0.0",
   "requirements": [
-    "pytapo==3.3.46",
+    "pytapo==3.3.49",
     "python-kasa[speedups]==0.10.2"
   ],
   "dependencies": [

--- a/custom_components/tapo_control/media_source.py
+++ b/custom_components/tapo_control/media_source.py
@@ -319,15 +319,13 @@ class TapoMediaSource(MediaSource):
                             build_identifier(
                                 {
                                     **query,
-                                    "title": childDevice["camData"]["basic_info"][
-                                        "device_name"
-                                    ],
+                                    "title": childDevice["name"],
                                     "childID": childDevice["camData"]["basic_info"][
                                         "dev_id"
                                     ],
                                 }
                             ),
-                            childDevice["camData"]["basic_info"]["device_name"],
+                            childDevice["name"],
                             False,
                             True,
                         )

--- a/custom_components/tapo_control/media_source.py
+++ b/custom_components/tapo_control/media_source.py
@@ -31,6 +31,9 @@ from .utils import (
 
 from pytapo import Tapo
 
+import json
+from urllib.parse import urlencode, urlparse, parse_qsl
+
 
 async def async_get_media_source(hass: HomeAssistant) -> TapoMediaSource:
     """Set up Radio Browser media source."""
@@ -40,6 +43,20 @@ async def async_get_media_source(hass: HomeAssistant) -> TapoMediaSource:
     entry = hass.config_entries.async_entries(DOMAIN)[0]
 
     return TapoMediaSource(hass, entry)
+
+
+def build_identifier(
+    params: dict[str, str | list[str]] = None, base: str = DOMAIN
+) -> str:
+    if params is None:
+        return f"{base}"
+    query = urlencode(params, doseq=True)
+    return f"{base}/?{query}"
+
+
+def parse_identifier(identifier: str) -> dict[str, str]:
+    query = urlparse(identifier).query
+    return dict(parse_qsl(query, keep_blank_values=True))
 
 
 class TapoMediaSource(MediaSource):
@@ -55,12 +72,15 @@ class TapoMediaSource(MediaSource):
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         path = item.identifier.split("/")
-        if len(path) == 5:
+        if len(path) == 2:
             try:
-                entry = path[1]
-                date = path[2]
-                startDate = int(path[3])
-                endDate = int(path[4])
+                query = parse_identifier(path[1])
+                LOGGER.debug(query)
+                entry = query["entry"]
+                date = query["date"]
+                startDate = query["startDate"]
+                endDate = query["endDate"]
+                isParent = self.hass.data[DOMAIN][entry]["isParent"]
                 if (
                     self.hass.data[DOMAIN][entry]["isDownloadingStream"]
                     and getFileName(startDate, endDate, False)
@@ -70,6 +90,15 @@ class TapoMediaSource(MediaSource):
                         "Already downloading a recording, please try again later."
                     )
                 tapoController: Tapo = self.hass.data[DOMAIN][entry]["controller"]
+
+                if isParent is True:
+                    childID = query["childID"]
+                    childrenDevice = None
+                    for child in self.hass.data[DOMAIN][entry]["childDevices"]:
+                        if child["camData"]["basic_info"]["dev_id"] == childID:
+                            childrenDevice = child
+                            break
+                    tapoController: Tapo = childrenDevice["controller"]
 
                 LOGGER.debug(startDate)
                 LOGGER.debug(endDate)
@@ -85,176 +114,214 @@ class TapoMediaSource(MediaSource):
 
             return PlayMedia(url, "video/mp4")
         else:
-            raise Unresolvable("Incorrect path.")
+            raise Unresolvable("Unexpected path.")
+
+    async def generateVideosForDate(self, query, title, entry, date, tapoController):
+        media_view_recordings_order = self.hass.data[DOMAIN][entry]["entry"].data.get(
+            MEDIA_VIEW_RECORDINGS_ORDER
+        )
+        if self.hass.data[DOMAIN][entry]["initialMediaScanDone"] is False:
+            raise Unresolvable(
+                "Initial local media scan still running, please try again later."
+            )
+        recordingsForDay = await getRecordings(self.hass, entry, tapoController, date)
+        videoNames = []
+        for searchResult in recordingsForDay:
+            for key in searchResult:
+                startTS = (
+                    searchResult[key]["startTime"]
+                    - self.hass.data[DOMAIN][entry]["timezoneOffset"]
+                )
+                endTS = (
+                    searchResult[key]["endTime"]
+                    - self.hass.data[DOMAIN][entry]["timezoneOffset"]
+                )
+                startDate = dt.as_local(dt.utc_from_timestamp(startTS))
+                endDate = dt.as_local(dt.utc_from_timestamp(endTS))
+                videoName = (
+                    f"{startDate.strftime('%H:%M:%S')} - {endDate.strftime('%H:%M:%S')}"
+                )
+                videoNames.append(
+                    {
+                        "name": videoName,
+                        "startDate": searchResult[key]["startTime"],
+                        "endDate": searchResult[key]["endTime"],
+                    }
+                )
+
+        videoNames = sorted(
+            videoNames,
+            key=lambda x: x["startDate"],
+            reverse=(True if media_view_recordings_order == "Descending" else False),
+        )
+
+        dateChildren = []
+        for data in videoNames:
+            fileName = getFileName(data["startDate"], data["endDate"], False)
+            thumbLink = None
+            if fileName in self.hass.data[DOMAIN][entry]["downloadedStreams"]:
+                thumbLink = await getWebFile(
+                    self.hass,
+                    entry,
+                    data["startDate"],
+                    data["endDate"],
+                    "thumbs",
+                )
+
+            dateChildren.append(
+                self.generateView(
+                    build_identifier(
+                        {
+                            **query,
+                            "title": data["name"],
+                            "startDate": data["startDate"],
+                            "endDate": data["endDate"],
+                        }
+                    ),
+                    data["name"],
+                    True,
+                    False,
+                    thumbnail=thumbLink,
+                )
+            )
+
+        return self.generateView(
+            build_identifier(query), title, False, True, children=dateChildren
+        )
+
+    async def generateDates(self, query, title, entry, tapoController):
+        media_view_days_order = self.hass.data[DOMAIN][entry]["entry"].data.get(
+            MEDIA_VIEW_DAYS_ORDER
+        )
+        if self.hass.data[DOMAIN][entry]["initialMediaScanDone"] is False:
+            raise Unresolvable(
+                "Initial local media scan still running, please try again later."
+            )
+
+        if self.hass.data[DOMAIN][entry]["usingCloudPassword"] is False:
+            raise Unresolvable(
+                "Cloud password is required in order to play recordings.\nSet cloud password inside Settings > Devices & Services > Tapo: Cameras Control > Configure."
+            )
+        recordingsList = await self.hass.async_add_executor_job(
+            tapoController.getRecordingsList
+        )
+        recordingsDates = []
+        for searchResult in recordingsList:
+            for key in searchResult:
+                recordingsDates.append(searchResult[key]["date"])
+
+        recordingsDates.sort(
+            reverse=True if media_view_days_order == "Descending" else False
+        )
+
+        return self.generateView(
+            build_identifier(query),
+            title,
+            False,
+            True,
+            children=[
+                self.generateView(
+                    build_identifier({**query, "title": date, "date": date}),
+                    date,
+                    False,
+                    True,
+                )
+                for date in recordingsDates
+            ],
+        )
+
+    def generateView(
+        self, identifier, title, can_play, can_expand, thumbnail=None, children=None
+    ):
+        return BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=identifier,
+            media_class=MediaClass.DIRECTORY,
+            media_content_type=MediaType.VIDEO,
+            title=title,
+            can_play=can_play,
+            can_expand=can_expand,
+            thumbnail=thumbnail,
+            children_media_class=MediaClass.DIRECTORY,
+            children=children,
+        )
 
     async def async_browse_media(
         self,
         item: MediaSourceItem,
     ) -> BrowseMediaSource:
         if item.identifier is None:
-            return BrowseMediaSource(
-                domain=DOMAIN,
-                identifier="tapo",
-                media_class=MediaClass.DIRECTORY,
-                media_content_type=MediaType.VIDEO,
-                title=self.name,
-                can_play=False,
-                can_expand=True,
-                children_media_class=MediaClass.DIRECTORY,
+            return self.generateView(
+                build_identifier(),
+                self.name,
+                False,
+                True,
                 children=[
-                    BrowseMediaSource(
-                        domain=DOMAIN,
-                        identifier=f"tapo/{entry}",
-                        media_class=MediaClass.DIRECTORY,
-                        media_content_type=MediaType.VIDEO,
-                        title=self.hass.data[DOMAIN][entry]["name"],
-                        can_play=False,
-                        can_expand=True,
+                    self.generateView(
+                        build_identifier(
+                            {
+                                "entry": entry,
+                                "title": self.hass.data[DOMAIN][entry]["name"],
+                            }
+                        ),
+                        self.hass.data[DOMAIN][entry]["name"],
+                        False,
+                        True,
                     )
                     for entry in self.hass.data[DOMAIN]
                 ],
             )
         else:
             path = item.identifier.split("/")
-            if len(path) == 2:
-                entry = path[1]
-                media_view_days_order = self.hass.data[DOMAIN][entry]["entry"].data.get(
-                    MEDIA_VIEW_DAYS_ORDER
-                )
-                if self.hass.data[DOMAIN][entry]["initialMediaScanDone"] is False:
-                    raise Unresolvable(
-                        "Initial local media scan still running, please try again later."
-                    )
+            if len(path) != 2:
+                raise Exception("Incorrect path, try navigating from Media again.")
 
-                if self.hass.data[DOMAIN][entry]["usingCloudPassword"] is False:
-                    raise Unresolvable(
-                        "Cloud password is required in order to play recordings.\nSet cloud password inside Settings > Devices & Services > Tapo: Cameras Control > Configure."
-                    )
-                tapoController: Tapo = self.hass.data[DOMAIN][entry]["controller"]
-                recordingsList = await self.hass.async_add_executor_job(
-                    tapoController.getRecordingsList
-                )
-                recordingsDates = []
-                for searchResult in recordingsList:
-                    for key in searchResult:
-                        recordingsDates.append(searchResult[key]["date"])
+            query = parse_identifier(path[1])
+            entry = query["entry"]
+            isParent = self.hass.data[DOMAIN][entry]["isParent"]
+            title = query["title"]
+            tapoController: Tapo = self.hass.data[DOMAIN][entry]["controller"]
+            if isParent is True:
+                if "childID" in query:
+                    childID = query["childID"]
+                    childrenDevice = None
+                    for child in self.hass.data[DOMAIN][entry]["childDevices"]:
+                        if child["camData"]["basic_info"]["dev_id"] == childID:
+                            childrenDevice = child
+                            break
+                    tapoController: Tapo = childrenDevice["controller"]
 
-                recordingsDates.sort(
-                    reverse=True if media_view_days_order == "Descending" else False
+            if "date" in query:
+                return await self.generateVideosForDate(
+                    query, title, entry, query["date"], tapoController
                 )
-                return BrowseMediaSource(
-                    domain=DOMAIN,
-                    identifier=f"tapo/{entry}",
-                    media_class=MediaClass.DIRECTORY,
-                    media_content_type=MediaType.VIDEO,
-                    title=self.hass.data[DOMAIN][entry]["name"],
-                    can_play=False,
-                    can_expand=True,
-                    children_media_class=MediaClass.DIRECTORY,
+            elif isParent is False or (isParent is True and "childID" in query):
+                return await self.generateDates(query, title, entry, tapoController)
+            elif isParent is True:
+                return self.generateView(
+                    build_identifier(query),
+                    self.hass.data[DOMAIN][entry]["name"],
+                    False,
+                    True,
                     children=[
-                        BrowseMediaSource(
-                            domain=DOMAIN,
-                            identifier=f"tapo/{entry}/{date}",
-                            media_class=MediaClass.DIRECTORY,
-                            media_content_type=MediaType.VIDEO,
-                            title=date,
-                            can_play=False,
-                            can_expand=True,
+                        self.generateView(
+                            build_identifier(
+                                {
+                                    **query,
+                                    "title": childDevice["camData"]["basic_info"][
+                                        "device_name"
+                                    ],
+                                    "childID": childDevice["camData"]["basic_info"][
+                                        "dev_id"
+                                    ],
+                                }
+                            ),
+                            childDevice["camData"]["basic_info"]["device_name"],
+                            False,
+                            True,
                         )
-                        for date in recordingsDates
+                        for childDevice in self.hass.data[DOMAIN][entry]["childDevices"]
                     ],
                 )
-            elif len(path) == 3:
-                entry = path[1]
-
-                media_view_recordings_order = self.hass.data[DOMAIN][entry][
-                    "entry"
-                ].data.get(MEDIA_VIEW_RECORDINGS_ORDER)
-                if self.hass.data[DOMAIN][entry]["initialMediaScanDone"] is False:
-                    raise Unresolvable(
-                        "Initial local media scan still running, please try again later."
-                    )
-                date = path[2]
-                tapoController: Tapo = self.hass.data[DOMAIN][entry]["controller"]
-                recordingsForDay = await getRecordings(self.hass, entry, date)
-                videoNames = []
-                for searchResult in recordingsForDay:
-                    for key in searchResult:
-                        startTS = (
-                            searchResult[key]["startTime"]
-                            - self.hass.data[DOMAIN][entry]["timezoneOffset"]
-                        )
-                        endTS = (
-                            searchResult[key]["endTime"]
-                            - self.hass.data[DOMAIN][entry]["timezoneOffset"]
-                        )
-                        startDate = dt.as_local(dt.utc_from_timestamp(startTS))
-                        endDate = dt.as_local(dt.utc_from_timestamp(endTS))
-                        videoName = f"{startDate.strftime('%H:%M:%S')} - {endDate.strftime('%H:%M:%S')}"
-                        videoNames.append(
-                            {
-                                "name": videoName,
-                                "startDate": searchResult[key]["startTime"],
-                                "endDate": searchResult[key]["endTime"],
-                            }
-                        )
-
-                videoNames = sorted(
-                    videoNames,
-                    key=lambda x: x["startDate"],
-                    reverse=(
-                        True if media_view_recordings_order == "Descending" else False
-                    ),
-                )
-
-                dateChildren = []
-                for data in videoNames:
-                    fileName = getFileName(data["startDate"], data["endDate"], False)
-                    if fileName in self.hass.data[DOMAIN][entry]["downloadedStreams"]:
-                        thumbLink = await getWebFile(
-                            self.hass,
-                            entry,
-                            data["startDate"],
-                            data["endDate"],
-                            "thumbs",
-                        )
-
-                        dateChildren.append(
-                            BrowseMediaSource(
-                                domain=DOMAIN,
-                                identifier=f"tapo/{entry}/{date}/{data['startDate']}/{data['endDate']}",
-                                media_class=MediaClass.VIDEO,
-                                media_content_type=MediaType.VIDEO,
-                                thumbnail=thumbLink,
-                                title=data["name"],
-                                can_play=True,
-                                can_expand=False,
-                            )
-                        )
-                    else:
-                        dateChildren.append(
-                            BrowseMediaSource(
-                                domain=DOMAIN,
-                                identifier=f"tapo/{entry}/{date}/{data['startDate']}/{data['endDate']}",
-                                media_class=MediaClass.VIDEO,
-                                media_content_type=MediaType.VIDEO,
-                                title=data["name"],
-                                can_play=True,
-                                can_expand=False,
-                            )
-                        )
-
-                return BrowseMediaSource(
-                    domain=DOMAIN,
-                    identifier=f"tapo/{entry}/",
-                    media_class=MediaClass.DIRECTORY,
-                    media_content_type=MediaType.VIDEO,
-                    title=f"{self.hass.data[DOMAIN][entry]['name']} - {date}",
-                    can_play=False,
-                    can_expand=True,
-                    children_media_class=MediaClass.DIRECTORY,
-                    children=dateChildren,
-                )
-
             else:
-                LOGGER.error("Not implemented")
+                raise Exception("Unexpected path.")

--- a/custom_components/tapo_control/media_source.py
+++ b/custom_components/tapo_control/media_source.py
@@ -106,14 +106,7 @@ class TapoMediaSource(MediaSource):
                 LOGGER.debug(endDate)
 
                 await getRecording(
-                    self.hass,
-                    tapoController,
-                    entry,
-                    device,
-                    date,
-                    startDate,
-                    endDate,
-                    childID=childID,
+                    self.hass, tapoController, entry, device, date, startDate, endDate
                 )
                 url = await getWebFile(
                     self.hass, entry, startDate, endDate, "videos", childID=childID

--- a/custom_components/tapo_control/switch.py
+++ b/custom_components/tapo_control/switch.py
@@ -21,7 +21,12 @@ async def async_setup_entry(
     switches = []
 
     async def setupEntities(entry):
-        entry_storage = Store(hass, version=1, key=getEntryStorageFile(config_entry))
+        childID = ""
+        if entry["isChild"]:
+            childID = entry["camData"]["basic_info"]["dev_id"]
+        entry_storage = Store(
+            hass, version=1, key=getEntryStorageFile(config_entry, childID)
+        )
         entry_stored_data = await entry_storage.async_load()
         switches = []
         tapoPrivacySwitch = await check_and_create(
@@ -269,16 +274,16 @@ class TapoEnableMediaSyncSwitch(TapoSwitchEntity):
         )
         self._entry_storage = entry_storage
         self._attr_state = "on" if savedValue else "off"
-        hass.data[DOMAIN][config_entry.entry_id][ENABLE_MEDIA_SYNC] = savedValue
+        entry[ENABLE_MEDIA_SYNC] = savedValue
 
     async def async_turn_on(self) -> None:
         await self._entry_storage.async_save({ENABLE_MEDIA_SYNC: True})
-        self._hass.data[DOMAIN][self._config_entry.entry_id][ENABLE_MEDIA_SYNC] = True
+        self._entry[ENABLE_MEDIA_SYNC] = True
         self._attr_state = "on"
 
     async def async_turn_off(self) -> None:
         await self._entry_storage.async_save({ENABLE_MEDIA_SYNC: False})
-        self._hass.data[DOMAIN][self._config_entry.entry_id][ENABLE_MEDIA_SYNC] = False
+        self._entry[ENABLE_MEDIA_SYNC] = False
         self._attr_state = "off"
 
     def updateTapo(self, camData):

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -445,12 +445,8 @@ async def mediaCleanup(hass, entry, deviceData):
         hass, entry_id, deviceData, ".jpg", "thumbs"
     )
 
-    await deleteColdFilesOlderThanMaxSyncTime(
-        hass, entry, deviceData, ".mp4", "videos", childID=childID
-    )
-    await deleteColdFilesOlderThanMaxSyncTime(
-        hass, entry, deviceData, ".jpg", "thumbs", childID=childID
-    )
+    await deleteColdFilesOlderThanMaxSyncTime(hass, entry, deviceData, ".mp4", "videos")
+    await deleteColdFilesOlderThanMaxSyncTime(hass, entry, deviceData, ".jpg", "thumbs")
 
     # Delete everything other than HOT_DIR_DELETE_TIME seconds from hot storage
     LOGGER.debug(

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -314,12 +314,15 @@ async def generateThumb(hass, entry_id, startDate: int, endDate: int, childID=""
 async def deleteFilesNoLongerPresentInCamera(
     hass, entry_id, entryData, extension, folder
 ):
+    LOGGER.debug("deleteFilesNoLongerPresentInCamera")
     childID = ""
     if entryData["isChild"]:
         childID = entryData["camData"]["basic_info"]["dev_id"]
     if entryData["initialMediaScanDone"] is True:
+        LOGGER.debug("deleteFilesNoLongerPresentInCamera - Initial scanning done.")
         coldDirPath = getColdDirPathForEntry(hass, entry_id)
         if os.path.exists(coldDirPath + "/" + folder + "/"):
+            LOGGER.debug("deleteFilesNoLongerPresentInCamera - path exists")
             listDirFiles = await hass.async_add_executor_job(
                 os.listdir, coldDirPath + "/" + folder + "/"
             )
@@ -332,8 +335,7 @@ async def deleteFilesNoLongerPresentInCamera(
                         (entryData["isChild"] is True and fileName.count("-") == 2)
                         and childID in fileName
                     )
-                    and fileName not in entryData["mediaScanResult"]
-                ):
+                ) and fileName not in entryData["mediaScanResult"]:
                     LOGGER.debug(
                         "[deleteFilesNoLongerPresentInCamera] Removing "
                         + filePath

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -210,7 +210,7 @@ def getEntryStorageFile(config_entry, child_id):
 # todo: findMedia needs to run periodically
 async def findMedia(hass, entryData, entry):
     entry_id = entry.entry_id
-    LOGGER.warning("Finding media for " + entryData["name"] + "...")
+    LOGGER.debug("Finding media for " + entryData["name"] + "...")
     entryData["initialMediaScanDone"] = False
     childID = ""
     if entryData["isChild"]:
@@ -253,7 +253,7 @@ async def findMedia(hass, entryData, entry):
                             recording[recordingKey]["endTime"],
                             childID=childID,
                         )
-    LOGGER.warning("Found media for " + entryData["name"] + ".")
+    LOGGER.debug("Found media for " + entryData["name"] + ".")
     entryData["mediaScanResult"] = mediaScanResult
     entryData["initialMediaScanDone"] = True
 
@@ -1933,14 +1933,14 @@ def isCacheSupported(check_function, rawData):
 
 
 async def scheduleAll(hass, device, entry, mediaSync):
-    LOGGER.warning("scheduleAll for " + device["name"] + " called.")
+    LOGGER.debug("scheduleAll for " + device["name"] + " called.")
     if device["mediaSyncAvailable"]:
         if (
             device["initialMediaScanDone"] is True
             and device["mediaSyncScheduled"] is False
         ):
             device["mediaSyncScheduled"] = True
-            LOGGER.warning("scheduling media sync")
+            LOGGER.debug("Scheduling media sync")
             callback = partial(mediaSync, entry=entry, device=device)
 
             entry.async_on_unload(
@@ -1951,7 +1951,7 @@ async def scheduleAll(hass, device, entry, mediaSync):
                 )
             )
         elif device["initialMediaScanRunning"] is False:
-            LOGGER.warning("media scan running")
+            LOGGER.debug("Media scan running")
             device["initialMediaScanRunning"] = True
             try:
                 await hass.async_add_executor_job(

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -13,7 +13,7 @@ import base64
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from pytapo.media_stream.downloader import Downloader
+from .pytapo.media_stream.downloader import Downloader
 from homeassistant.components.media_source.error import Unresolvable
 
 from haffmpeg.tools import IMAGE_JPEG, ImageFrame
@@ -178,8 +178,7 @@ def getHotDirPathForEntry(hass: HomeAssistant, entry_id: str):
     return hotDirPath.rstrip("/")
 
 
-async def getRecordings(hass, entry_id, date):
-    tapoController: Tapo = hass.data[DOMAIN][entry_id]["controller"]
+async def getRecordings(hass, entry_id, tapoController, date):
     LOGGER.debug("Getting recordings for date " + date + "...")
     recordingsForDay = await hass.async_add_executor_job(
         tapoController.getRecordings, date
@@ -214,7 +213,7 @@ async def findMedia(hass, entry):
         for key in searchResult:
             LOGGER.debug(f"Getting media for day {searchResult[key]['date']}...")
             recordingsForDay = await getRecordings(
-                hass, entry_id, searchResult[key]["date"]
+                hass, entry_id, tapoController, searchResult[key]["date"]
             )
             LOGGER.debug(
                 f"Looping through recordings for day {searchResult[key]['date']}..."
@@ -540,6 +539,8 @@ async def getRecording(
     totalRecordingCount: int = False,
 ) -> str:
     timeCorrection = await hass.async_add_executor_job(tapo.getTimeCorrection)
+    startDate = int(startDate)
+    endDate = int(endDate)
 
     coldDirPath = getColdDirPathForEntry(hass, entry_id)
     downloadUID = getFileName(startDate, endDate, False)

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -207,7 +207,7 @@ def getEntryStorageFile(config_entry):
 # todo: findMedia needs to run periodically
 async def findMedia(hass, entryData, entry):
     entry_id = entry.entry_id
-    LOGGER.warning(
+    LOGGER.debug(
         "Finding media for " + entryData["camData"]["basic_info"]["device_name"] + "..."
     )
     entryData["initialMediaScanDone"] = False
@@ -220,11 +220,11 @@ async def findMedia(hass, entryData, entry):
     mediaScanResult = {}
     for searchResult in recordingsList:
         for key in searchResult:
-            LOGGER.warning(f"Getting media for day {searchResult[key]['date']}...")
+            LOGGER.debug(f"Getting media for day {searchResult[key]['date']}...")
             recordingsForDay = await getRecordings(
                 hass, entryData, tapoController, searchResult[key]["date"]
             )
-            LOGGER.warning(
+            LOGGER.debug(
                 f"Looping through recordings for day {searchResult[key]['date']}..."
             )
             for recording in recordingsForDay:
@@ -319,8 +319,6 @@ async def deleteFilesNoLongerPresentInCamera(
             for f in listDirFiles:
                 fileName = f.replace(extension, "")
                 filePath = os.path.join(coldDirPath + "/" + folder + "/", f)
-                LOGGER.warning(fileName)
-                LOGGER.warning(entryData["mediaScanResult"])
                 if (
                     (entryData["isChild"] is False and fileName.count("-") == 1)
                     or (
@@ -329,8 +327,7 @@ async def deleteFilesNoLongerPresentInCamera(
                     )
                     and fileName not in entryData["mediaScanResult"]
                 ):
-
-                    LOGGER.warning(
+                    LOGGER.debug(
                         "[deleteFilesNoLongerPresentInCamera] Removing "
                         + filePath
                         + " ("
@@ -371,21 +368,12 @@ async def deleteColdFilesOlderThanMaxSyncTime(
                     (entryData["isChild"] is True and fileName.count("-") == 2)
                     and childID in fileName
                 ):
-                    LOGGER.warning(
-                        (entryData["isChild"] is False and fileName.count("-") == 1)
-                    )
-                    LOGGER.warning("or")
-                    LOGGER.warning(
-                        (entryData["isChild"] is True and fileName.count("-") == 2)
-                    )
-                    LOGGER.warning("and")
-                    LOGGER.warning(childID in fileName)
                     endTS = int(fileName.split("-")[len(splitFileName) - 1])
                     last_modified = os.stat(filePath).st_mtime
                     if (endTS < (int(ts) - (int(mediaSyncTime) + timeCorrection))) and (
                         ts - last_modified > int(mediaSyncTime)
                     ):
-                        LOGGER.warning(
+                        LOGGER.debug(
                             "[deleteColdFilesOlderThanMaxSyncTime] Removing "
                             + filePath
                             + " ("
@@ -429,7 +417,7 @@ async def mediaCleanup(hass, entry, deviceData):
     hotDirPath = getHotDirPathForEntry(hass, entry_id)
 
     # clean cache files from old HA instance
-    LOGGER.warning(
+    LOGGER.debug(
         "Removing cache files from old HA instances for entity "
         + entry_id
         + ", child ID:'"
@@ -455,7 +443,7 @@ async def mediaCleanup(hass, entry, deviceData):
     )
 
     # Delete everything other than HOT_DIR_DELETE_TIME seconds from hot storage
-    LOGGER.warning(
+    LOGGER.debug(
         "Deleting hot storage files older than "
         + str(HOT_DIR_DELETE_TIME)
         + " seconds for entity "
@@ -464,8 +452,8 @@ async def mediaCleanup(hass, entry, deviceData):
         + childID
         + "..."
     )
-    # await deleteFilesOlderThan(hass, hotDirPath + "/videos/", HOT_DIR_DELETE_TIME)
-    # await deleteFilesOlderThan(hass, hotDirPath + "/thumbs/", HOT_DIR_DELETE_TIME)
+    await deleteFilesOlderThan(hass, hotDirPath + "/videos/", HOT_DIR_DELETE_TIME)
+    await deleteFilesOlderThan(hass, hotDirPath + "/thumbs/", HOT_DIR_DELETE_TIME)
 
 
 async def deleteDir(hass, dirPath):
@@ -509,7 +497,7 @@ def processDownloadStatus(
     recordingCount: int = False,
 ):
     def processUpdate(status):
-        LOGGER.warning(status)
+        LOGGER.debug(status)
         if isinstance(status, str):
             entryData["downloadProgress"] = status
         else:

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -251,7 +251,6 @@ async def findMedia(hass, entryData, entry):
                             entryData,
                             recording[recordingKey]["startTime"],
                             recording[recordingKey]["endTime"],
-                            childID=childID,
                         )
     LOGGER.debug("Found media for " + entryData["name"] + ".")
     entryData["mediaScanResult"] = mediaScanResult
@@ -261,8 +260,11 @@ async def findMedia(hass, entryData, entry):
 
 
 async def processDownload(
-    hass, entry_id: int, entryData: dict, startDate: int, endDate: int, childID=""
+    hass, entry_id: int, entryData: dict, startDate: int, endDate: int
 ):
+    childID = ""
+    if entryData["isChild"]:
+        childID = entryData["camData"]["basic_info"]["dev_id"]
     filePath = getFileName(startDate, endDate, False, childID=childID)
 
     coldFilePath = getColdFile(
@@ -310,8 +312,11 @@ async def generateThumb(hass, entry_id, startDate: int, endDate: int, childID=""
 
 # todo: findMedia needs to run periodically because of this function!!!
 async def deleteFilesNoLongerPresentInCamera(
-    hass, entry_id, entryData, extension, folder, childID=""
+    hass, entry_id, entryData, extension, folder
 ):
+    childID = ""
+    if entryData["isChild"]:
+        childID = entryData["camData"]["basic_info"]["dev_id"]
     if entryData["initialMediaScanDone"] is True:
         coldDirPath = getColdDirPathForEntry(hass, entry_id)
         if os.path.exists(coldDirPath + "/" + folder + "/"):
@@ -344,8 +349,11 @@ async def deleteFilesNoLongerPresentInCamera(
 
 
 async def deleteColdFilesOlderThanMaxSyncTime(
-    hass, entry, entryData, extension, folder, childID=""
+    hass, entry, entryData, extension, folder
 ):
+    childID = ""
+    if entryData["isChild"]:
+        childID = entryData["camData"]["basic_info"]["dev_id"]
     entry_id = entry.entry_id
     mediaSyncHours = entry.data.get(MEDIA_SYNC_HOURS)
 
@@ -431,10 +439,10 @@ async def mediaCleanup(hass, entry, deviceData):
     await deleteFilesNotIncluding(hass, hotDirPath + "/thumbs/", UUID)
 
     await deleteFilesNoLongerPresentInCamera(
-        hass, entry_id, deviceData, ".mp4", "videos", childID=childID
+        hass, entry_id, deviceData, ".mp4", "videos"
     )
     await deleteFilesNoLongerPresentInCamera(
-        hass, entry_id, deviceData, ".jpg", "thumbs", childID=childID
+        hass, entry_id, deviceData, ".jpg", "thumbs"
     )
 
     await deleteColdFilesOlderThanMaxSyncTime(
@@ -662,9 +670,7 @@ async def getRecording(
             },
         )
 
-    await processDownload(
-        hass, entry_id, entryData, startDate, endDate, childID=childID
-    )
+    await processDownload(hass, entry_id, entryData, startDate, endDate)
 
     return coldFilePath
 

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -249,6 +249,7 @@ async def findMedia(hass, entryData, entry):
                         )
     entryData["mediaScanResult"] = mediaScanResult
     entryData["initialMediaScanDone"] = True
+
     await mediaCleanup(hass, entry, entryData=entryData, childID=childID)
 
 
@@ -520,7 +521,9 @@ async def getHotFile(
     folder: str,
     childID="",
 ):
-    coldFilePath = getColdFile(hass, entry_id, startDate, endDate, folder)
+    coldFilePath = getColdFile(
+        hass, entry_id, startDate, endDate, folder, childID=childID
+    )
     hotDirPath = getHotDirPathForEntry(hass, entry_id)
     extension = pathlib.Path(coldFilePath).suffix
     fileNameEncrypted = getFileName(startDate, endDate, True, childID=childID)

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -18,7 +18,7 @@ from homeassistant.components.media_source.error import Unresolvable
 
 from haffmpeg.tools import IMAGE_JPEG, ImageFrame
 from onvif import ONVIFCamera
-from pytapo import Tapo
+from .pytapo import Tapo
 from yarl import URL
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -15,12 +15,12 @@ from functools import partial
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from .pytapo.media_stream.downloader import Downloader
+from pytapo.media_stream.downloader import Downloader
 from homeassistant.components.media_source.error import Unresolvable
 
 from haffmpeg.tools import IMAGE_JPEG, ImageFrame
 from onvif import ONVIFCamera
-from .pytapo import Tapo
+from pytapo import Tapo
 from yarl import URL
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 


### PR DESCRIPTION
# 7.0.0 🎥 1️⃣1️⃣1️⃣ • 0️⃣ • 0️⃣

# New Features

## Stream on battery, solar & hub devices

Integration now supports video stream through proprietary TP-Link protocol - called Direct stream. These Direct stream camera entities will automatically show up as enabled _HD (Direct)_ and _SD (Direct)_ (disabled by default), if RTSP streaming is not available for your camera.
If you have RTSP entities already, Direct entities will be disabled by default, but can be manually enabled.

### Why use the new streams?
1. **If you have a device which does not have RTSP functionality, you now have a stream in HA. This includes battery devices, solar devices, _as well as devices working through a hub_.** 🤯
2. If you have used up [all your RTSP streams](https://www.tp-link.com/cz/support/faq/2742/) and/or your RTSP streams are unstable in Home Assistant.
3. They are _extremely_ fast to load and have less than a half a second delay in stream* (*make sure to DISABLE `Use Stream from Home Assistant (restart required)` in integration options for the fastest experience and best battery life). **Measured delay is lower than RTSP with go2rtc.** Under the hood, the new streams are a binary stream of data "straight to your browser", with no unnecessary translations or overhead.

### Why not use the new Direct streams?

If you have an option to use RTSP, consider sticking with RTSP streams.

1. Direct streams take a bit more CPU resources since the device running this integration is now handling the binary stream directly, instead of camera exposing a standardized RTSP stream.
2. Direct streams cannot be used with webrtc card, or go2rtc.
3. RTSP streams are very fast with almost no delay with [webrtc](https://github.com/AlexxIT/WebRTC) camera card

## Recording downloads on battery, solar & hub devices & Media Sync

Similarly to streams, recorded videos can now be viewed inside Home Assistant on all cameras out there, including solar, battery, or hub devices.

They can be also automatically synced using the [Media Sync](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control?tab=readme-ov-file#media-sync).

# Fixes

- Fix #1006: Edge case where adding a camera failed
- Fix #1001: Edge case where reloading an integration required Home Assistant restart

# Thank you

- @GracefulTabby for [initial research & code on recordings download for hub devices](https://github.com/JurajNyiri/pytapo/issues/57)
- @rivergo1d for sharing his D230 doorbell with me allowing me to quickly test all the changes