### PR TITLE
Fix update entity log string syntax

### DIFF
--- a/custom_components/tapo_control/update.py
+++ b/custom_components/tapo_control/update.py
@@ -61,7 +61,7 @@ class TapoCamUpdate(UpdateEntity):
         # on this entity and cancelling in progress update
         LOGGER.debug("updateTapo in update entity")
         if camData and camData["updated"] > self._lastDataUpdate:
-            LOGGER.debug(f"Processing new data (updated at {camData["updated"]})...")
+            LOGGER.debug(f"Processing new data (updated at {camData['updated']})...")
             self._lastDataUpdate = camData["updated"]
             self._attributes = camData["basic_info"]
             if self._in_progress:


### PR DESCRIPTION
Fix Update Entity Syntax

  - `custom_components/tapo_control/update.py:64` used a double-quoted f-string containing
    camData["updated"], causing Python to terminate the string early and crash when loading the
    integration.
  - Replaced the inner quotes with single quotes so the log line is valid; module now compiles/
    imports (`python3 -m py_compile custom_components/tapo_control/update.py`).
