### PR TITLE
Use `name_by_user` when available

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -75,6 +75,7 @@ from .utils import (
     getDataForController,
     getEntryStorageFile,
     getHotDirPathForEntry,
+    get_device_name,
     getIP,
     isUsingHTTPS,
     mediaCleanup,
@@ -1033,7 +1034,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "eventsListener": False,
             "entities": [],
             "noiseSensorStarted": False,
-            "name": camData["basic_info"]["device_alias"],
+            "name": get_device_name(hass, camData["basic_info"]),
             "childDevices": [],
             "isRunningOnBattery": (
                 True
@@ -1139,7 +1140,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                                 "runningMediaSync": False,
                                 "mediaScanResult": {},  # keeps track of all videos currently on camera
                                 "entities": [],
-                                "name": childCamData["basic_info"]["device_alias"],
+                                "name": get_device_name(hass, childCamData["basic_info"]),
                                 "childDevices": [],
                                 "isChild": True,
                                 "isRunningOnBattery": (

--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -404,7 +404,7 @@ class TapoMotionSensor(BinarySensorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return build_device_info(self._attributes)
+        return build_device_info(self._attributes, self._name)
 
     @property
     def model(self):

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -242,6 +242,7 @@ class TapoCamEntity(Camera):
         self._extra_arguments = config_entry.data.get(CONF_EXTRA_ARGUMENTS)
         self._enable_stream = config_entry.data.get(ENABLE_STREAM)
         self._attr_extra_state_attributes = entry["camData"]["basic_info"]
+        self._device_name = entry["name"]
         self._attr_icon = "mdi:cctv"
         self._attr_should_poll = True
         self._is_cam_entity = True
@@ -266,7 +267,7 @@ class TapoCamEntity(Camera):
 
     @property
     def name(self) -> str:
-        name = self._attr_extra_state_attributes["device_alias"]
+        name = self._device_name
         name += f" {self._stream_label} Stream"
         if self._directStream:
             name += " (Direct)"
@@ -280,7 +281,7 @@ class TapoCamEntity(Camera):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return build_device_info(self._attr_extra_state_attributes)
+        return build_device_info(self._attr_extra_state_attributes, self._device_name)
 
     @property
     def motion_detection_enabled(self):

--- a/custom_components/tapo_control/tapo/entities.py
+++ b/custom_components/tapo_control/tapo/entities.py
@@ -24,10 +24,7 @@ class TapoEntity(Entity):
         self._enabled = False
         self._is_cam_entity = False
         self._is_noise_sensor = False
-        if self._entry["isChild"]:
-            self._name = entry["camData"]["basic_info"]["device_alias"]
-        else:
-            self._name = entry["name"]
+        self._name = entry["name"]
         self._name_suffix = name_suffix
         self._controller = entry["controller"]
         self._coordinator = entry["coordinator"]
@@ -39,7 +36,7 @@ class TapoEntity(Entity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return build_device_info(self._attributes)
+        return build_device_info(self._attributes, self._name)
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/tapo_control/update.py
+++ b/custom_components/tapo_control/update.py
@@ -49,7 +49,7 @@ class TapoCamUpdate(UpdateEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return build_device_info(self._attributes)
+        return build_device_info(self._attributes, self._name)
 
     @property
     def unique_id(self) -> str:
@@ -81,7 +81,7 @@ class TapoCamUpdate(UpdateEntity):
                     )
                     # Update Device Registry with new information
                     deviceRegistry = dr.async_get(self._hass)
-                    newDeviceInfo = build_device_info(camData["basic_info"])
+                    newDeviceInfo = build_device_info(camData["basic_info"], self._name)
                     device = deviceRegistry.async_get_device(
                         newDeviceInfo["identifiers"]
                     )

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -25,6 +25,7 @@ from yarl import URL
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers import device_registry as dr
 from homeassistant.components.ffmpeg import DATA_FFMPEG
 from homeassistant.components.onvif.event import EventManager
 from homeassistant.const import (
@@ -2064,11 +2065,57 @@ async def setupEvents(hass, config_entry):
             return False
 
 
-def build_device_info(attributes: dict) -> DeviceInfo:
+def get_device_name(
+    hass: HomeAssistant, attributes: dict, fallback_name: str = None
+) -> str:
+    """Get device name prioritizing name_by_user over device_alias.
+    
+    Checks the device registry for a user-customized name (name_by_user).
+    Falls back to device_alias if no user customization exists.
+    
+    Args:
+        hass: Home Assistant instance
+        attributes: Device attributes containing 'mac' and 'device_alias'
+        fallback_name: Optional fallback name if device_alias is not available
+    
+    Returns:
+        The preferred device name
+    """
+    device_alias = attributes.get("device_alias", fallback_name or "Tapo Camera")
+    
+    if hass is None:
+        return device_alias
+    
+    try:
+        device_registry = dr.async_get(hass)
+        device_identifier = (DOMAIN, slugify(f"{attributes['mac']}_tapo_control"))
+        device = device_registry.async_get_device(identifiers={device_identifier})
+        
+        if device and device.name_by_user:
+            LOGGER.debug(
+                f"Using name_by_user '{device.name_by_user}' for device {attributes['mac']}"
+            )
+            return device.name_by_user
+    except Exception as e:
+        LOGGER.debug(f"Could not get device from registry: {e}")
+    
+    return device_alias
+
+
+def build_device_info(attributes: dict, name_override: str = None) -> DeviceInfo:
+    """Build DeviceInfo for a Tapo device.
+    
+    Args:
+        attributes: Device attributes containing mac, device_alias, device_model, etc.
+        name_override: Optional name to use instead of device_alias
+    
+    Returns:
+        DeviceInfo object for the device
+    """
     return DeviceInfo(
         identifiers={(DOMAIN, slugify(f"{attributes['mac']}_tapo_control"))},
         connections={("mac", attributes["mac"])},
-        name=attributes["device_alias"],
+        name=name_override if name_override else attributes["device_alias"],
         manufacturer=BRAND,
         model=attributes["device_model"],
         sw_version=attributes["sw_version"],


### PR DESCRIPTION
A fix for #1171. It summarizes the issue pretty well.
Basically, the component always uses the Tapo name even when the device is renamed in Home Assistant, resulting in entity_ids and entity friendly names that don't match the device name.

In my case, I have a Chime plugged in but not the doorbell. Because the doorbell is unplugged, the Tapo app does not allow me to rename it, and the chime name is tied to the doorbell name. Having to manually maintain the names and entity_id of each entity is not ideal.
This PR updates the naming logic to use the Home Assistant device name when available, falling back to the current behaviour when not set.