### PR TITLE
Update PYTAPO_REQUIRED_VERSION

### DIFF
--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import config_validation as cv
 TPLINK_DOMAIN = "tplink"
 
 CONTROL_PORT = "control_port"
-PYTAPO_REQUIRED_VERSION = "3.4.11"
+PYTAPO_REQUIRED_VERSION = ">=3.4.11"
 DOMAIN = "tapo_control"
 DOMAIN_CONFIG = DOMAIN + "_config"
 BRAND = "TP-Link"


### PR DESCRIPTION
Fix compatibility issues due to dependency and version mismatch.

https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/1075