### PR TITLE
Guard coordinator _enabled checks to avoid refresh crashes

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -800,7 +800,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             allEntities = getAllEntities(hass.data[DOMAIN][entry.entry_id])
             for entity in allEntities:
                 LOGGER.debug(entity["entity"])
-                if entity["entity"]._enabled:
+                if getattr(entity["entity"], "_enabled", False):
                     LOGGER.debug("async_update_data - enabling someEntityEnabled check")
                     someEntityEnabled = True
                     break
@@ -910,7 +910,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
                     for entity in allEntities:
                         if (
-                            entity["entity"]._enabled
+                            getattr(entity["entity"], "_enabled", False)
                             and entity["entry"]["controller"]
                             in updateDataForAllControllers
                         ):
@@ -935,9 +935,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                             ):
                                 await entity["entity"].startNoiseDetection()
 
-                if ("updateEntity" in hass.data[DOMAIN][entry.entry_id]) and hass.data[
-                    DOMAIN
-                ][entry.entry_id]["updateEntity"]._enabled:
+                if ("updateEntity" in hass.data[DOMAIN][entry.entry_id]) and getattr(
+                    hass.data[DOMAIN][entry.entry_id]["updateEntity"],
+                    "_enabled",
+                    False,
+                ):
                     hass.data[DOMAIN][entry.entry_id]["updateEntity"].updateTapo(
                         camData
                     )


### PR DESCRIPTION
## Summary

Guard coordinator `_enabled` checks in the refresh loop so missing `_enabled` attributes do not crash updates.

## Problem

During coordinator refresh, the integration directly accesses private `_enabled` attributes on entity objects in `custom_components/tapo_control/__init__.py`.

In some cases, entities such as `TapoEnableMediaSyncSwitch` do not expose `_enabled`, which raises an `AttributeError` and causes the refresh cycle to fail.

This was also spamming Home Assistant logs repeatedly. Example from my logs, with environment-specific details redacted:

```text
2026-04-21 22:10:58.061 ERROR (MainThread) [custom_components.tapo_control] Unexpected error fetching Tapo resource status data
Traceback (most recent call last):
  File "/.../homeassistant/helpers/update_coordinator.py", line 419, in _async_refresh
    self.data = await self._async_update_data()
  File "/.../homeassistant/helpers/update_coordinator.py", line 308, in _async_update_data
    return await self.update_method()
  File "/config/custom_components/tapo_control/__init__.py", line 913, in async_update_data
    entity["entity"]._enabled
AttributeError: 'TapoEnableMediaSyncSwitch' object has no attribute '_enabled'. Did you mean: 'enabled'?
```

Because this happens inside the coordinator refresh path, the update cycle fails, entity state can go stale, and the logs fill with repeated errors.

## Fix

Replace direct `_enabled` attribute access with defensive `getattr(..., "_enabled", False)` checks in the coordinator refresh logic.

This preserves existing behavior when `_enabled` exists, and safely treats entities with no `_enabled` attribute as disabled instead of crashing the refresh loop.
