### PR TITLE
Fix: Improve video stream stability by adjusting ffmpeg parameters

### DIFF
--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -578,9 +578,10 @@ class TapoDirectCamEntity(TapoCamEntity):
             quality=self._directQuality,
             logFunction=self.logFunction,
             ff_args={
+                "-probesize": "50000",
+                "-analyzeduration": "1000000",
                 "-c:v": "mjpeg",
                 "-f": "mpjpeg",
-                "-vsync": "0",
                 "-map-video": f"0:v:{self.videoStream}",
             },
         )


### PR DESCRIPTION
Fix: Direct MJPEG stream stops after few seconds on HEVC cameras #1125 

Cameras like the C560WS (4K HEVC) send periodic IDR resets that cause PTS to go non-monotonic. The -vsync 0 flag passed timestamps through unchanged, causing the mjpeg encoder to reject frames with Invalid pts <= last. Removing it lets ffmpeg handle timestamps automatically.

Also increased probesize (32→50000) and analyzeduration (0→1000000) as the original values were insufficient for HEVC stream detection, causing immediate stream failure.

Tested on C560WS (3840x2160 HEVC 25fps HD + 1280x720 H.264 50fps SD). No tested on any other devices.

You likely added -vsync 0 for the fastest possible passthrough on older H.264-only cameras where timestamps were always monotonic. It just wasn't tested against newer HEVC cameras with IDR resets.

