### PR TITLE
fix: guard TapoMotionSensor against False camData when camera unreachable

### DIFF
--- a/custom_components/tapo_control/binary_sensor.py
+++ b/custom_components/tapo_control/binary_sensor.py
@@ -330,11 +330,13 @@ class EventsListener:
         events = self.metaData["events"]
         name = self.metaData["name"]
         camData = self.metaData["camData"]
-        entities = {
-            event.uid: TapoMotionSensor(event.uid, events, name, camData)
-            for event in events.get_platform("binary_sensor")
-        }
-        self.async_add_entities(entities.values())
+        entities = {}
+        if camData:
+            entities = {
+                event.uid: TapoMotionSensor(event.uid, events, name, camData)
+                for event in events.get_platform("binary_sensor")
+            }
+            self.async_add_entities(entities.values())
         uids_by_platform = events.get_uids_by_platform("binary_sensor")
 
         @callback
@@ -343,8 +345,13 @@ class EventsListener:
             nonlocal uids_by_platform
             if not (missing := uids_by_platform.difference(entities)):
                 return
+            currentCamData = self.metaData["camData"]
+            if not currentCamData:
+                LOGGER.debug("async_check_entities - camData not ready; will retry")
+                return
             new_entities: dict[str, TapoMotionSensor] = {
-                uid: TapoMotionSensor(uid, events, name, camData) for uid in missing
+                uid: TapoMotionSensor(uid, events, name, currentCamData)
+                for uid in missing
             }
             LOGGER.debug("async_check_entities2")
             if new_entities:


### PR DESCRIPTION
## Problem

When a camera is unreachable, `camData` comes back as `False`. `TapoMotionSensor.__init__` does:

```python
self._attributes = camData["basic_info"]
```

with no guard, raising `TypeError: 'bool' object is not subscriptable` from inside the ONVIF event callback:

```
File "custom_components/tapo_control/binary_sensor.py", line 347, in async_check_entities
File "custom_components/tapo_control/binary_sensor.py", line 363, in __init__
    self._attributes = camData["basic_info"]
TypeError: 'bool' object is not subscriptable
```

Because the crash happens in the constructor (before `async_add_entities`), the motion `binary_sensor` is never created, and the callback floods the log — **471 occurrences in ~12h** on my instance whenever the camera blips off the network.

This was the only creation path missing the guard — the same file already uses the safe pattern at line ~191 (`entry.get("camData", {}).get("basic_info", {})`).

## Fix

- In `createBinarySensor`, skip creation while `camData` is falsy.
- In the `async_check_entities` listener, re-read `camData` fresh from `self.metaData` (the captured closure value goes stale at `False`) and defer creation until the camera is reachable.

The sensor then self-heals on the next motion event, with no crash.

## Verification

Tested live on HA 2026.6 / Tapo Control 7.1.14:
- Camera went unreachable (`camData == False`) — **no `TypeError` logged** (previously it would flood).
- `camData` recovered; on the next motion event the `binary_sensor` was created successfully and went to `off`.

Note: `device_info`/`model` require `basic_info` keys (`mac`, `device_alias`, `device_model`, ...), so an empty-dict fallback would just move the crash to those property accessors — deferring until `camData` is valid avoids that.
