### PR TITLE
Fix #484: Remember presets on failure of retrieval, and force refresh on privacy change

### DIFF
--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -39,7 +39,7 @@ from .const import (
     CONF_CUSTOM_STREAM_7,
 )
 from .utils import (
-    async_refresh_after_privacy_mode_change,
+    async_force_entry_refresh,
     build_device_info,
     getStreamSource,
 )
@@ -394,7 +394,7 @@ class TapoCamEntity(Camera):
             self._controller.setPrivacyMode,
             False,
         )
-        await async_refresh_after_privacy_mode_change(self._hass, self._entry)
+        await async_force_entry_refresh(self._hass, self._entry)
 
     async def async_turn_off(self):
         LOGGER.debug("async_turn_off - camera")
@@ -402,7 +402,7 @@ class TapoCamEntity(Camera):
             self._controller.setPrivacyMode,
             True,
         )
-        await async_refresh_after_privacy_mode_change(self._hass, self._entry)
+        await async_force_entry_refresh(self._hass, self._entry)
 
     async def save_preset(self, name):
         LOGGER.debug("save_preset - camera")

--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -38,7 +38,11 @@ from .const import (
     CONF_CUSTOM_STREAM_6,
     CONF_CUSTOM_STREAM_7,
 )
-from .utils import build_device_info, getStreamSource
+from .utils import (
+    async_refresh_after_privacy_mode_change,
+    build_device_info,
+    getStreamSource,
+)
 
 
 async def async_setup_entry(
@@ -390,7 +394,7 @@ class TapoCamEntity(Camera):
             self._controller.setPrivacyMode,
             False,
         )
-        await self._coordinator.async_request_refresh()
+        await async_refresh_after_privacy_mode_change(self._hass, self._entry)
 
     async def async_turn_off(self):
         LOGGER.debug("async_turn_off - camera")
@@ -398,7 +402,7 @@ class TapoCamEntity(Camera):
             self._controller.setPrivacyMode,
             True,
         )
-        await self._coordinator.async_request_refresh()
+        await async_refresh_after_privacy_mode_change(self._hass, self._entry)
 
     async def save_preset(self, name):
         LOGGER.debug("save_preset - camera")

--- a/custom_components/tapo_control/manifest.json
+++ b/custom_components/tapo_control/manifest.json
@@ -6,7 +6,7 @@
   "codeowners": [
     "@JurajNyiri"
   ],
-  "version": "7.1.14",
+  "version": "7.1.15",
   "requirements": [
     "pytapo==3.4.14",
     "python-kasa[speedups]==0.10.2"

--- a/custom_components/tapo_control/select.py
+++ b/custom_components/tapo_control/select.py
@@ -1611,17 +1611,20 @@ class TapoMoveToPresetSelect(TapoSelectEntity):
         await self._coordinator.async_request_refresh()
 
     def updateTapo(self, camData):
-        if not camData or camData["privacy_mode"] == "on":
+        if not camData:
             self._attr_state = STATE_UNAVAILABLE
+            return
+
+        self._presets = camData["presets"]
+        self._attr_options = list(camData["presets"].values())
+
+        if camData["privacy_mode"] == "on":
+            self._attr_state = STATE_UNAVAILABLE
+        elif self._presets:
+            self._attr_current_option = None
+            self._attr_state = self._attr_current_option
         else:
-            self._presets = camData["presets"]
-            presetsConvertedToList = list(camData["presets"].values())
-            if presetsConvertedToList:
-                self._attr_options = list(camData["presets"].values())
-                self._attr_current_option = None
-                self._attr_state = self._attr_current_option
-            else:
-                self._attr_state = STATE_UNAVAILABLE
+            self._attr_state = STATE_UNAVAILABLE
 
     async def async_select_option(self, option: str) -> None:
         foundKey = False

--- a/custom_components/tapo_control/switch.py
+++ b/custom_components/tapo_control/switch.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, LOGGER, ENABLE_MEDIA_SYNC, MEDIA_SYNC_HOURS
 from .tapo.entities import TapoSwitchEntity
 from .utils import (
+    async_refresh_after_privacy_mode_change,
     check_and_create,
     check_functionality,
     getColdDirPathForEntry,
@@ -959,7 +960,7 @@ class TapoPrivacySwitch(TapoSwitchEntity):
         if "error_code" not in result or result["error_code"] == 0:
             self._attr_state = "on"
         self.async_write_ha_state()
-        await self._coordinator.async_request_refresh()
+        await async_refresh_after_privacy_mode_change(self._hass, self._entry)
 
     async def async_turn_off(self) -> None:
         result = await self._hass.async_add_executor_job(
@@ -969,7 +970,7 @@ class TapoPrivacySwitch(TapoSwitchEntity):
         if "error_code" not in result or result["error_code"] == 0:
             self._attr_state = "off"
         self.async_write_ha_state()
-        await self._coordinator.async_request_refresh()
+        await async_refresh_after_privacy_mode_change(self._hass, self._entry)
 
     def updateTapo(self, camData):
         if not camData:

--- a/custom_components/tapo_control/switch.py
+++ b/custom_components/tapo_control/switch.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, LOGGER, ENABLE_MEDIA_SYNC, MEDIA_SYNC_HOURS
 from .tapo.entities import TapoSwitchEntity
 from .utils import (
-    async_refresh_after_privacy_mode_change,
+    async_force_entry_refresh,
     check_and_create,
     check_functionality,
     getColdDirPathForEntry,
@@ -960,7 +960,7 @@ class TapoPrivacySwitch(TapoSwitchEntity):
         if "error_code" not in result or result["error_code"] == 0:
             self._attr_state = "on"
         self.async_write_ha_state()
-        await async_refresh_after_privacy_mode_change(self._hass, self._entry)
+        await async_force_entry_refresh(self._hass, self._entry)
 
     async def async_turn_off(self) -> None:
         result = await self._hass.async_add_executor_job(
@@ -970,7 +970,7 @@ class TapoPrivacySwitch(TapoSwitchEntity):
         if "error_code" not in result or result["error_code"] == 0:
             self._attr_state = "off"
         self.async_write_ha_state()
-        await async_refresh_after_privacy_mode_change(self._hass, self._entry)
+        await async_force_entry_refresh(self._hass, self._entry)
 
     def updateTapo(self, camData):
         if not camData:

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.components.ffmpeg import DATA_FFMPEG
+
 try:
     # Home Assistant moved EventManager from `event` to `event_manager` in 2026.5.
     from homeassistant.components.onvif.event_manager import EventManager
@@ -91,9 +92,7 @@ def isUsingHTTPS(hass):
 def mark_entry_data_for_refresh(hass: HomeAssistant, entry: dict) -> None:
     config_entry = entry.get("entry")
     root_entry = (
-        hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
-        if config_entry
-        else None
+        hass.data.get(DOMAIN, {}).get(config_entry.entry_id) if config_entry else None
     )
     if root_entry is None:
         root_entry = entry
@@ -106,12 +105,6 @@ def mark_entry_data_for_refresh(hass: HomeAssistant, entry: dict) -> None:
 async def async_force_entry_refresh(hass: HomeAssistant, entry: dict) -> None:
     mark_entry_data_for_refresh(hass, entry)
     await entry["coordinator"].async_request_refresh()
-
-
-async def async_refresh_after_privacy_mode_change(
-    hass: HomeAssistant, entry: dict
-) -> None:
-    await async_force_entry_refresh(hass, entry)
 
 
 def getStreamSource(entry, stream):

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -88,6 +88,32 @@ def isUsingHTTPS(hass):
     return URL(base_url).scheme == "https"
 
 
+def mark_entry_data_for_refresh(hass: HomeAssistant, entry: dict) -> None:
+    config_entry = entry.get("entry")
+    root_entry = (
+        hass.data.get(DOMAIN, {}).get(config_entry.entry_id)
+        if config_entry
+        else None
+    )
+    if root_entry is None:
+        root_entry = entry
+
+    root_entry["lastUpdate"] = 0
+    for child in root_entry.get("childDevices", []):
+        child["lastUpdate"] = 0
+
+
+async def async_force_entry_refresh(hass: HomeAssistant, entry: dict) -> None:
+    mark_entry_data_for_refresh(hass, entry)
+    await entry["coordinator"].async_request_refresh()
+
+
+async def async_refresh_after_privacy_mode_change(
+    hass: HomeAssistant, entry: dict
+) -> None:
+    await async_force_entry_refresh(hass, entry)
+
+
 def getStreamSource(entry, stream):
     custom_stream_hd = entry.data.get(CONF_CUSTOM_STREAM_HD, "")
     custom_stream_sd = entry.data.get(CONF_CUSTOM_STREAM_SD, "")


### PR DESCRIPTION
### Changes

- Fix https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/484: Preset configuration lost from time to time
- Fix #1325: Guard TapoMotionSensor against False camData when camera unreachable, thank you @benjamin-m-holden
- Fix https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/1026: H200 hub SD card capacity sensors are text not number-with-unit, thank you @Spamfast
