### PR TITLE
docs: hints regarding special characters in cloud pw

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ After every step, test if camera works in HA, and after each step try checking T
 
 1. Ensure you have Third Party Compatibility turned on in official Tapo app on your smartphone. Tapo App -> Me -> Third-Party Compatibility -> On
 2. Try checking Third-Party Compatibility off and on again and opening the camera via Tapo App, while being on the same network as the camera is.
-3. Reset your password.
+3. Reset your password. Some special characters in your Tapo cloud password may cause authentication to fail on certain camera models. If the password prompt keeps reappearing, try changing your Tapo cloud password to one using only letters, numbers and characters like `_ - @`.
 4. Make sure your camera can access the internet.
 5. Reboot your camera a few times.
 6. Reset the camera. Remove it from your account, do a factory reset, add it back with internet access, add it back to the integration.

--- a/custom_components/tapo_control/strings.json
+++ b/custom_components/tapo_control/strings.json
@@ -14,7 +14,7 @@
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nNote: Some special characters in your Tapo cloud password may cause authentication to fail on certain camera models. If the password prompt keeps reappearing, try changing your Tapo cloud password to one using only letters, numbers and characters like _ - @ ."
       },
       "ip": {
         "data": {
@@ -43,7 +43,7 @@
           "cloud_username": "Username",
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nNote: Some special characters in your Tapo cloud password may cause authentication to fail on certain camera models. If the password prompt keeps reappearing, try changing your Tapo cloud password to one using only letters, numbers and characters like _ - @ ."
       },
       "auth_optional_cloud": {
         "data": {

--- a/custom_components/tapo_control/translations/en.json
+++ b/custom_components/tapo_control/translations/en.json
@@ -14,7 +14,7 @@
         "data": {
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nNote: Some special characters in your Tapo cloud password may cause authentication to fail on certain camera models. If the password prompt keeps reappearing, try changing your Tapo cloud password to one using only letters, numbers and characters like _ - @ ."
       },
       "ip": {
         "data": {
@@ -43,7 +43,7 @@
           "cloud_username": "Username",
           "cloud_password": "Cloud Password"
         },
-        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local."
+        "description": "Camera requires your cloud password for control.\nThis is the password which you used with your email when signing into the Tapo app.\nEnsure you have Third-Party compatibility turned on in Tapo App (Me -> Tapo Lab -> Third-Party Compatibility - On).\n\nTapo Care paid subscription is not required.\nUnless you used the same password for cloud as for your Camera account, this password is not the same.\nEmail is not needed and all communication is still fully local.\n\nNote: Some special characters in your Tapo cloud password may cause authentication to fail on certain camera models. If the password prompt keeps reappearing, try changing your Tapo cloud password to one using only letters, numbers and characters like _ - @ ."
       },
       "auth_optional_cloud": {
         "data": {


### PR DESCRIPTION
On adding a C720 camera while adding the cloud password I got all the time an error with the incorrect cloud password (double checked it on the App). I had those special characters within my password: ` !>)"`. Seems to be a parsing related error on the camera directly.

AI generated this list of special characters which should cause an issue: `! > ) " # & | \ ; space`, did not test it out, therefore not committed this list.