### PR TITLE
Prevent transient SSL/network errors from triggering ConfigEntryAuthFailed

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -99,6 +99,28 @@ from datetime import timedelta
 from .utils import getRecording
 
 
+MAX_AUTH_RETRIES = 10
+
+
+def _is_network_error(e: Exception) -> bool:
+    """Return True for transient SSL/network errors that should never count as auth failures."""
+    err_str = str(e).lower()
+    return any(
+        marker in err_str
+        for marker in (
+            "ssl",
+            "httpsconnectionpool",
+            "connectionerror",
+            "timeout",
+            "eof occurred",
+            "unexpected_eof",
+            "connection aborted",
+            "connection reset",
+            "remotedisconnected",
+        )
+    )
+
+
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Tapo: Cameras Control component from YAML."""
     transport_method = None
@@ -269,6 +291,8 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             LOGGER.error(
                 "Unable to connect to Tapo: Cameras Control controller: %s", str(e)
             )
+            if _is_network_error(e):
+                raise ConfigEntryNotReady
             if "Invalid authentication data" in str(e):
                 raise ConfigEntryAuthFailed(e)
             elif "Temporary Suspension:" in str(
@@ -372,6 +396,8 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             LOGGER.error(
                 "Unable to connect to Tapo: Cameras Control controller: %s", str(e)
             )
+            if _is_network_error(e):
+                raise ConfigEntryNotReady
             if "Invalid authentication data" in str(e):
                 raise ConfigEntryAuthFailed(e)
             elif "Temporary Suspension:" in str(
@@ -888,8 +914,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                             controllerData["reauth_retries"] = 0
                         except Exception as e:
                             updateDataForAllControllers[controller] = False
+                            if _is_network_error(e):
+                                LOGGER.debug("Transient network error, will retry: %s", e)
+                                raise e
                             if str(e) == "Invalid authentication data":
-                                if controllerData["reauth_retries"] < 3:
+                                if controllerData["reauth_retries"] < MAX_AUTH_RETRIES:
                                     controllerData["reauth_retries"] += 1
                                     raise e
                                 else:
@@ -1344,8 +1373,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
     except Exception as e:
+        if _is_network_error(e):
+            LOGGER.debug("Transient network error during setup, will retry: %s", e)
+            raise ConfigEntryNotReady(e)
         if "Invalid authentication data" in str(e):
-            if hass.data[DOMAIN][entry.entry_id]["setup_retries"] < 3:
+            if hass.data[DOMAIN][entry.entry_id]["setup_retries"] < MAX_AUTH_RETRIES:
                 hass.data[DOMAIN][entry.entry_id]["setup_retries"] += 1
                 raise ConfigEntryNotReady(e)
             raise ConfigEntryAuthFailed(e)


### PR DESCRIPTION
## Problem

When a Tapo camera is temporarily unreachable or the SSL connection is disrupted, the integration raises `ConfigEntryAuthFailed` after only 3 consecutive failures, prompting the user to re-enter their credentials — even though the credentials are perfectly valid.

This is particularly visible on Python 3.12+ where `SSLEOFError: UNEXPECTED_EOF_WHILE_READING` is raised on every request to Tapo cameras (which do not properly close TLS connections). Three SSL errors in a row immediately trigger a credential prompt, which is confusing and disruptive.

## Root cause

The existing retry logic (`setup_retries`, `reauth_retries`) does not distinguish between:
- **Genuine authentication failures**: the camera explicitly rejects the credentials (`Invalid authentication data`)
- **Transient network/SSL failures**: the connection dropped, timed out, or the TLS handshake failed

Both types of error were counted against the same retry counter, so a brief network hiccup could exhaust the 3-retry budget and escalate to `ConfigEntryAuthFailed`.

## Changes

### `_is_network_error()` helper

A new helper function checks whether an exception is a transient network or SSL error by inspecting the exception message for known markers:
- `ssl`, `httpsconnectionpool`, `connectionerror`, `timeout`
- `eof occurred`, `unexpected_eof`, `connection aborted`, `connection reset`, `remotedisconnected`

### Updated error handling in 4 locations

1. **Migration code** (2 occurrences): network errors now raise `ConfigEntryNotReady` immediately, never `ConfigEntryAuthFailed`
2. **`async_update_data`** (`reauth_retries`): network errors are retried silently without incrementing the auth counter
3. **`async_setup_entry`** (`setup_retries`): same — network errors don't count toward the auth threshold

### `MAX_AUTH_RETRIES = 10`

The hard-coded `3` threshold is replaced by a named constant set to `10`. Even genuine but transient auth failures (e.g. camera firmware briefly rejecting connections after a reboot) now require 10 consecutive misses before the user is prompted.

## Backward compatibility

- No change to the credential flow or UI
- Cameras with actually wrong credentials still eventually raise `ConfigEntryAuthFailed` (after 10 genuine auth failures)
- No new dependencies

## Testing

Tested on Home Assistant 2026.6 / Python 3.14 with Tapo C220 and C325WB. Prior to this fix, every HASS restart triggered a credential prompt due to SSL errors during startup. After this fix, cameras reconnect silently after transient errors.