### PR TITLE
Fix: extend ONVIF unsubscribe timeout + log silent setupEvents failures

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -507,11 +507,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if hass.data[DOMAIN][entry.entry_id]["events"]:
         LOGGER.debug("Stopping events...")
         try:
-            async with asyncio.timeout(3):
+            # 3s was too short for some cameras (notably D130 doorbell) when
+            # the ONVIF unsubscribe round-trip is slow. Timing out here leaves
+            # zombie subscriptions on the camera side; after several reloads
+            # the camera reaches its subscription limit and silently rejects
+            # new ones — motion/person/pet binary_sensors then never get
+            # created. See issues #1199 and #865.
+            async with asyncio.timeout(10):
                 await hass.data[DOMAIN][entry.entry_id]["events"].async_stop()
-        except (asyncio.TimeoutError, ClientError):
+        except (asyncio.TimeoutError, ClientError) as e:
             LOGGER.warning(
-                "Timed out waiting for onvif connection to close, proceeding."
+                "Timed out waiting for onvif connection to close (10s), "
+                "proceeding. Camera-side subscription may leak. Error: %s",
+                e,
             )
         LOGGER.debug("Events stopped.")
 

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -2124,8 +2124,33 @@ async def setupEvents(hass, config_entry):
         pull_point_support = onvif_capabilities.get("Events", {}).get(
             "WSPullPointSupport"
         )
-        LOGGER.debug("WSPullPointSupport: %s", pull_point_support)
-        if await events.async_start(pull_point_support is not False, shouldUseWebhooks):
+        LOGGER.debug(
+            "[setupEvents] device=%s WSPullPointSupport=%s shouldUseWebhooks=%s",
+            config_entry.data.get("ip_address"),
+            pull_point_support,
+            shouldUseWebhooks,
+        )
+        try:
+            started = await events.async_start(
+                pull_point_support is not False, shouldUseWebhooks
+            )
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.error(
+                "[setupEvents] device=%s events.async_start raised %s: %s",
+                config_entry.data.get("ip_address"),
+                type(exc).__name__,
+                exc,
+            )
+            started = False
+        if not started:
+            LOGGER.warning(
+                "[setupEvents] device=%s events.async_start returned False; "
+                "motion/person/pet binary_sensors will NOT be created. "
+                "Common causes: stale subscriptions on camera (try reboot), "
+                "ONVIF event service unavailable.",
+                config_entry.data.get("ip_address"),
+            )
+        if started:
             LOGGER.debug("Events started.")
             if not hass.data[DOMAIN][config_entry.entry_id]["motionSensorCreated"]:
                 hass.data[DOMAIN][config_entry.entry_id]["motionSensorCreated"] = True


### PR DESCRIPTION
## Problem

Multiple users (#1199, #865) report that AI-detection binary_sensors (`motion_alarm`, `person_detection`, `pet_detection`, `cell_motion_detection`) silently disappear from a Tapo integration entry after several reloads/restarts, and cannot be brought back by reload, restart, integration reinstall, or deleting + re-adding the entry.

I reproduced this on a **Tapo D130 doorbell** (firmware 1.1.12 Build 250806). A C210 on the same HA instance was unaffected until similar conditions.

## Root cause

In `async_unload_entry` (`__init__.py:510`):

```python
async with asyncio.timeout(3):
    await hass.data[DOMAIN][entry.entry_id]["events"].async_stop()
```

For some cameras (D130 in my testing) the ONVIF unsubscribe is slower than 3s. When this times out the subscription stays alive on the camera. After several reloads the cam reaches its subscription slot limit and silently rejects new ones.

Then `events.async_start(...)` in `setupEvents` (`utils.py:2128`) returns `False`, but the code path silently drops the failure:

```python
if await events.async_start(...):
    ...
    return True
else:
    return False  # no log, no error
```

The eventsListener never calls `createBinarySensor`, so motion-related entities never get created. To users this looks like a missing-feature bug rather than a transport-layer problem.

## Symptoms

- Only `binary_sensor.<cam>_noise` and `<cam>_doorbell` exist
- Motion / person / pet / cell_motion sensors missing from the registry entirely
- Re-adding creates 50+ other entities (buttons, switches, selects, etc) but no motion binary_sensors
- HA logs silent about the failure

## Fix

1. **`__init__.py`**: raise unsubscribe timeout from 3s to 10s, include the original exception in the warning.
2. **`utils.py setupEvents`**: wrap `events.async_start` in try/except, emit warning-level log on `False` or exception. Previously swallowed.

Neither change is risky — timeout extension only matters for slow-unsubscribing cameras, the new log is only emitted on the failure path that had no diagnostics.

## Verification

D130 before patch: after several reloads, motion sensors gone, no log clue. After patch + single HA restart, all four sensors recreated and events flow:

```
binary_sensor.jardin_camara_timbre_motion_alarm           state=on   ✅
binary_sensor.jardin_camara_timbre_cell_motion_detection  state=on   ✅
binary_sensor.jardin_camara_timbre_person_detection       state=on   ✅
binary_sensor.jardin_camara_timbre_pet_detection          state=off  ✅
```

Sensor states actively changing as people walk past. Doorbell button + noise sensor remained working throughout (they use different transport, that's why those are the only two that survive the bug).

## Related

- #1199 — Binary sensor entities for AI detection missing
- #865 — Motion Sensor stops working after restart
- #1157 — C610 Solar Kit Missing Binary Motion Sensor