### PR TITLE
Guard battery media scans and direct streams

### DIFF
--- a/custom_components/tapo_control/camera.py
+++ b/custom_components/tapo_control/camera.py
@@ -45,6 +45,19 @@ from .utils import (
 )
 
 
+def _direct_stream_entities_blocked(entry) -> bool:
+    if not entry.get("isRunningOnBattery"):
+        return False
+
+    basic_info = entry.get("camData", {}).get("basic_info", {})
+    alias = basic_info.get("device_alias") or entry.get("name") or "battery camera"
+    LOGGER.warning(
+        "Skipping direct stream entities for battery-powered camera %s",
+        alias,
+    )
+    return True
+
+
 def _clear_location_coordinates(attributes: dict) -> None:
     attributes.pop("longitude", None)
     attributes.pop("latitude", None)
@@ -164,7 +177,7 @@ async def async_setup_entry(
                     )
                 async_add_entities(telephotoEntities)
 
-        if not entry["isParent"]:
+        if not entry["isParent"] and not _direct_stream_entities_blocked(entry):
 
             allChnInfo = entry.get("camData", {}).get("allChnInfo", {})
             if allChnInfo:

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -2268,6 +2268,11 @@ def isCacheSupported(check_function, rawData):
 
 async def scheduleAll(hass, device, entry, mediaSync):
     LOGGER.debug("scheduleAll for " + device["name"] + " called.")
+    if not device.get(ENABLE_MEDIA_SYNC):
+        device["initialMediaScanRunning"] = False
+        device["runningMediaSync"] = False
+        return
+
     if device["mediaSyncAvailable"]:
         if (
             device["initialMediaScanDone"] is True


### PR DESCRIPTION
This adds two battery-camera safety guards:

- scheduleAll() now returns immediately when media sync is disabled, clearing any stale scan/sync flags before returning. This prevents the initial media scan from running even though the media-sync switch is off.
- Direct stream entities are skipped for battery-powered cameras. Direct stream setup/use can keep battery cameras awake and, in my HA Core 2026.7.0 setup, repeated direct-stream/ffmpeg failures were enough to wedge Core while the frontend buffered.

The RTSP entities for configured credentials are left unchanged; this only avoids creating the direct stream entity path for battery devices.

Validation run locally:

```bash
python3 -m py_compile custom_components/tapo_control/utils.py custom_components/tapo_control/camera.py
```

