### PR TITLE
Fix: C320WS controls, media sync recovery, siren state sync, and coordinator reliability

### DIFF
--- a/custom_components/tapo_control/__init__.py
+++ b/custom_components/tapo_control/__init__.py
@@ -1003,6 +1003,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         LOGGER.debug(f"Timezone offset is {timezoneOffset}.")
 
         LOGGER.debug("Setting up entry data.")
+        # async_on_unload removes the listener on unload; without it every
+        # config entry reload registered an additional listener, so
+        # update_listener ran multiple times per options change.
+        entry.async_on_unload(entry.add_update_listener(update_listener))
         hass.data[DOMAIN][entry.entry_id] = {
             "setup_retries": 0,
             "reauth_retries": 0,
@@ -1014,7 +1018,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "chInfo": chInfo,
             "usingCloudPassword": cloud_password != "",
             "allControllers": [tapoController],
-            "update_listener": entry.add_update_listener(update_listener),
             "coordinator": tapoCoordinator,
             "camData": camData,
             "lastTimeSync": 0,

--- a/custom_components/tapo_control/button.py
+++ b/custom_components/tapo_control/button.py
@@ -8,7 +8,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 
 from .const import DOMAIN, LOGGER
 from .tapo.entities import TapoButtonEntity
-from .utils import syncTime, check_and_create, result_has_error
+from .utils import syncTime, check_and_create, result_has_error, supports_manual_siren
 
 
 async def async_setup_entry(
@@ -26,19 +26,25 @@ async def async_setup_entry(
             if entry["controller"].isKLAP is False:
                 buttons.append(TapoFormatButton(entry, hass, config_entry))
 
-            tapoStartManualAlarmButton = await check_and_create(
-                entry, hass, TapoStartManualAlarmButton, "getAlarm", config_entry
-            )
-            if tapoStartManualAlarmButton:
-                LOGGER.debug("Adding tapoStartManualAlarmButton...")
-                buttons.append(tapoStartManualAlarmButton)
+            if supports_manual_siren(entry.get("camData")):
+                tapoStartManualAlarmButton = await check_and_create(
+                    entry, hass, TapoStartManualAlarmButton, "getAlarm", config_entry
+                )
+                if tapoStartManualAlarmButton:
+                    LOGGER.debug("Adding tapoStartManualAlarmButton...")
+                    buttons.append(tapoStartManualAlarmButton)
 
-            tapoStopManualAlarmButton = await check_and_create(
-                entry, hass, TapoStopManualAlarmButton, "getAlarm", config_entry
-            )
-            if tapoStopManualAlarmButton:
-                LOGGER.debug("Adding tapoStopManualAlarmButton...")
-                buttons.append(tapoStopManualAlarmButton)
+                tapoStopManualAlarmButton = await check_and_create(
+                    entry, hass, TapoStopManualAlarmButton, "getAlarm", config_entry
+                )
+                if tapoStopManualAlarmButton:
+                    LOGGER.debug("Adding tapoStopManualAlarmButton...")
+                    buttons.append(tapoStopManualAlarmButton)
+            else:
+                LOGGER.debug(
+                    "Skipping Manual Alarm buttons: model does not support "
+                    "manual siren."
+                )
 
             if not entry["isParent"] and entry["controller"].isKLAP is False:
                 buttons.append(TapoSyncTimeButton(entry, hass, config_entry))

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -106,3 +106,11 @@ TAPO_PREFIXES = (
     r"^d[0-9]{3}[a-zA-Z]*c_.*",  # Doorbell Chimes (D100C, D230C, D325C, etc.)
     r"^h[0-9]{3}[a-zA-Z]*_.*",  # Smart Hubs (H100, H200, H300, etc.)
 )
+
+# Models with no way to trigger the siren on demand: startManualAlarm,
+# setSirenStatus and testUsrDefAudio all return -40106/-40210 and the Tapo
+# app offers no manual siren button for them (alarm only fires on motion
+# detection). Creating the Siren entity or the Manual Alarm Start/Stop
+# buttons for these models gives users controls that always fail.
+# See #373, #678 and discussion #978.
+MODELS_WITHOUT_MANUAL_SIREN = ("C320WS",)

--- a/custom_components/tapo_control/number.py
+++ b/custom_components/tapo_control/number.py
@@ -754,6 +754,23 @@ class TapoSpotlightIntensity(TapoNumberEntity):
             )
             self._attr_max_value = 100
             self._attr_native_max_value = 100
+
+        # Some C320WS firmwares report getLdc style as "original" together
+        # with a smartwtl_digital_level of 100, yet the camera rejects any
+        # intensity above 5 with -40101 (the Tapo app also only offers 1-5
+        # for this model). See #979.
+        device_model = (
+            entry.get("camData", {}).get("basic_info", {}).get("device_model") or ""
+        )
+        if device_model.startswith("C320WS") and self._attr_max_value > 5:
+            LOGGER.debug(
+                "Capping TapoSpotlightIntensity max at 5 for %s (reported %s)",
+                device_model,
+                self._attr_max_value,
+            )
+            self._attr_max_value = 5
+            self._attr_native_max_value = 5
+
         self._attr_step = 1
         self._hass = hass
         intensity = entry["camData"]["whitelampConfigIntensity"]

--- a/custom_components/tapo_control/select.py
+++ b/custom_components/tapo_control/select.py
@@ -429,7 +429,8 @@ class TapoChimeSoundPlay(RestoreEntity, TapoSelectEntity):
 
     def updateTapo(self, camData):
         if (
-            "supportAlarmTypeList" not in camData
+            not camData
+            or "supportAlarmTypeList" not in camData
             or camData["supportAlarmTypeList"] is None
         ):
             self._attr_state = STATE_UNAVAILABLE
@@ -1127,12 +1128,12 @@ class TapoDualCamLinkage(TapoSelectEntity):
 
     def updateTapo(self, camData):
         LOGGER.debug(f"TapoDualCamLinkage updateTapo 1")
-        LOGGER.debug(f"Enabled: {camData["dualCamLinkageEnabled"]}")
-        LOGGER.debug(f"Type: {camData["dualCamLinkageType"]}")
         if not camData:
             LOGGER.debug("TapoDualCamLinkage updateTapo 2")
             self._attr_state = STATE_UNAVAILABLE
         else:
+            LOGGER.debug(f"Enabled: {camData["dualCamLinkageEnabled"]}")
+            LOGGER.debug(f"Type: {camData["dualCamLinkageType"]}")
             LOGGER.debug("TapoDualCamLinkage updateTapo 3")
             if camData["dualCamLinkageEnabled"] == "off":
                 LOGGER.debug("TapoDualCamLinkage updateTapo 4")
@@ -1192,7 +1193,11 @@ class TapoMotionDetectionSelect(TapoSelectEntity):
 
     def updateTapo(self, camData):
         LOGGER.debug(f"TapoMotionDetectionSelect updateTapo 1 ({self.chn_id})")
-        if not camData:
+        if (
+            not camData
+            or not camData.get("motion_detection_enabled")
+            or not camData.get("motion_detection_sensitivity")
+        ):
             LOGGER.debug("TapoMotionDetectionSelect updateTapo 2")
             self._attr_state = STATE_UNAVAILABLE
         else:

--- a/custom_components/tapo_control/siren.py
+++ b/custom_components/tapo_control/siren.py
@@ -124,7 +124,6 @@ class TapoSiren(TapoSirenEntity):
             else:
                 self._attr_available = False
                 raise Exception("Camera does not support triggering the siren.")
-        self._is_on = True
         if duration:
             self._turn_off_task = self.hass.async_create_task(
                 _turn_off_after(duration, True)
@@ -193,7 +192,7 @@ class TapoSiren(TapoSirenEntity):
             self._attr_available = False
         else:
             self._attr_available = True
-            self._is_on = camData["alarm_status"] == "on"
+            self._attr_is_on = camData["alarm_status"] == "on"
             if (
                 "alarm_config" in camData
                 and camData["alarm_config"]

--- a/custom_components/tapo_control/siren.py
+++ b/custom_components/tapo_control/siren.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, LOGGER
 from .tapo.entities import TapoEntity
-from .utils import check_and_create, result_has_error
+from .utils import check_and_create, result_has_error, supports_manual_siren
 
 
 async def async_setup_entry(
@@ -21,6 +21,11 @@ async def async_setup_entry(
 
     async def setupEntities(entry):
         sirens = []
+        if not supports_manual_siren(entry.get("camData")):
+            LOGGER.debug(
+                "Skipping Siren entity: model does not support manual siren."
+            )
+            return sirens
         tapoSiren = await check_and_create(
             entry, hass, TapoSiren, "getAlarm", config_entry
         )

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -59,6 +59,7 @@ from .const import (
     CONF_CUSTOM_STREAM_7,
     MEDIA_SYNC_COLD_STORAGE_PATH,
     MEDIA_SYNC_HOURS,
+    MODELS_WITHOUT_MANUAL_SIREN,
     TIME_SYNC_DST,
     TIME_SYNC_NDST,
     TPLINK_DOMAIN,
@@ -806,6 +807,18 @@ def result_has_error(result):
         return False
     else:
         return True
+
+
+def supports_manual_siren(camData):
+    """Whether the camera can trigger its siren on demand. Known-unsupported
+    models are listed in MODELS_WITHOUT_MANUAL_SIREN; for those we skip
+    creating the Siren entity and the Manual Alarm Start/Stop buttons."""
+    if not camData:
+        return True
+    device_model = (camData.get("basic_info") or {}).get("device_model") or ""
+    return not any(
+        device_model.startswith(prefix) for prefix in MODELS_WITHOUT_MANUAL_SIREN
+    )
 
 
 async def initOnvifEvents(hass, host, username, password):

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -280,6 +280,23 @@ def getEntryStorageFile(config_entry, child_id):
 
 # todo: findMedia needs to run periodically
 async def findMedia(hass, entryData, entry):
+    try:
+        await _findMedia(hass, entryData, entry)
+    except Exception as err:
+        # Allow scheduleAll to retry the initial scan on the next update
+        # cycle. Without this, a transient error here would leave
+        # initialMediaScanRunning stuck on True and the media pipeline
+        # (recordings UI, media sync, cold storage cleanup) disabled until
+        # Home Assistant restarts.
+        entryData["initialMediaScanRunning"] = False
+        LOGGER.error(
+            "Initial media scan for %s failed, will retry: %s",
+            entryData["name"],
+            err,
+        )
+
+
+async def _findMedia(hass, entryData, entry):
     entry_id = entry.entry_id
     LOGGER.debug("Finding media for " + entryData["name"] + "...")
     entryData["initialMediaScanDone"] = False
@@ -713,19 +730,24 @@ async def getRecording(
         )
 
         entryData["isDownloadingStream"] = True
-        downloadedFile = await downloader.downloadFile(
-            processDownloadStatus(
-                entryData,
-                date,
-                (
-                    len(allRecordings)
-                    if totalRecordingCount is False
-                    else totalRecordingCount
-                ),
-                recordingCount if recordingCount is not False else False,
+        try:
+            downloadedFile = await downloader.downloadFile(
+                processDownloadStatus(
+                    entryData,
+                    date,
+                    (
+                        len(allRecordings)
+                        if totalRecordingCount is False
+                        else totalRecordingCount
+                    ),
+                    recordingCount if recordingCount is not False else False,
+                )
             )
-        )
-        entryData["isDownloadingStream"] = False
+        finally:
+            # Without this, a single failed download would leave
+            # isDownloadingStream stuck on True, permanently blocking both
+            # media sync and manual playback until Home Assistant restarts.
+            entryData["isDownloadingStream"] = False
         if downloadedFile["currentAction"] == "Recording in progress":
             raise Unresolvable("Recording is currently in progress.")
 


### PR DESCRIPTION
## Summary
This PR bundles C320WS-specific quality-of-life fixes with several reliability fixes found during a full-repo audit using **Fable** (automated code review), each manually verified before implementation.
### C320WS
- **Spotlight intensity (#979):** Some C320WS firmwares report `smartwtl_digital_level` as 100 while the camera rejects anything above 5 with `-40101`. The Tapo app only exposes 1–5. Cap `TapoSpotlightIntensity` max at 5 when `device_model` starts with `C320WS`.
- **Manual siren / alarm controls (#373, #678, discussion #978):** C320WS has no on-demand siren API (`startManualAlarm`, `setSirenStatus`, and `testUsrDefAudio` return `-40106`/`-40210`; the Tapo app has no manual siren button). Add `MODELS_WITHOUT_MANUAL_SIREN` and skip the Siren entity and Manual Alarm Start/Stop buttons for matching models so users do not get controls that always fail.
### Reliability (found with Fable)
- **Siren state sync:** `updateTapo` wrote `self._is_on`, which `SirenEntity` ignores. External alarm triggers (motion, Tapo app) never updated the HA toggle. Use `_attr_is_on`.
- **Media pipeline:** `isDownloadingStream` could stay `True` after a failed download, permanently blocking sync and playback until restart — wrapped in `try/finally`. Initial `findMedia` now resets `initialMediaScanRunning` on failure so the scan can retry instead of leaving the recordings UI stuck.
- **Select crashes on failed poll:** When `getCamData` fails, `camData` is `False` and three `updateTapo` methods raised `TypeError`, aborting the entire entity update cycle (`TapoDualCamLinkage`, `TapoChimeSoundPlay`, `TapoMotionDetectionSelect`). Guard before subscripting.
- **Config reload:** `update_listener` was registered on every setup but never removed on unload, stacking duplicate listeners after each reload. Register via `entry.async_on_unload`.
## How the general fixes were found
**Fable** was run over the integration (event-loop safety, entity lifecycle, resource cleanup). Several automated suggestions were discarded as false positives (e.g. `_attr_state` on number entities where base classes override `state`). Only confirmed issues are included here.
## Test plan
- [x] **C320WS:** Spotlight Intensity max is 5; values 1–5 apply without `-40101`
- [x] **C320WS:** Siren toggle and Manual Alarm Start/Stop buttons are not created
- [ ] **Other cameras:** Siren entity and alarm buttons still appear where supported; spotlight range unchanged on non-C320WS models
- [ ] **Siren (supported model):** Toggle reflects alarm status after external trigger
- [ ] **Media sync:** Failed download does not block sync/playback until restart; initial scan retries after transient error
- [ ] **Network blip during poll:** Entities go unavailable instead of coordinator logging `TypeError` from select entities
- [ ] **Options change + reload:** `update_listener` runs once per change, not N times