### PR TITLE
Fix #979: C320WS spotlight intensity cap; skip manual siren entities on unsupported models

### DIFF
--- a/custom_components/tapo_control/button.py
+++ b/custom_components/tapo_control/button.py
@@ -26,7 +26,7 @@ async def async_setup_entry(
             if entry["controller"].isKLAP is False:
                 buttons.append(TapoFormatButton(entry, hass, config_entry))
 
-            if supports_manual_siren(entry.get("camData")):
+            if await supports_manual_siren(hass, entry):
                 tapoStartManualAlarmButton = await check_and_create(
                     entry, hass, TapoStartManualAlarmButton, "getAlarm", config_entry
                 )
@@ -42,8 +42,8 @@ async def async_setup_entry(
                     buttons.append(tapoStopManualAlarmButton)
             else:
                 LOGGER.debug(
-                    "Skipping Manual Alarm buttons: model does not support "
-                    "manual siren."
+                    "Skipping Manual Alarm buttons: on-demand manual siren "
+                    "unavailable."
                 )
 
             if not entry["isParent"] and entry["controller"].isKLAP is False:

--- a/custom_components/tapo_control/button.py
+++ b/custom_components/tapo_control/button.py
@@ -8,7 +8,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 
 from .const import DOMAIN, LOGGER
 from .tapo.entities import TapoButtonEntity
-from .utils import syncTime, check_and_create, result_has_error
+from .utils import syncTime, check_and_create, result_has_error, supports_manual_siren
 
 
 async def async_setup_entry(
@@ -26,19 +26,25 @@ async def async_setup_entry(
             if entry["controller"].isKLAP is False:
                 buttons.append(TapoFormatButton(entry, hass, config_entry))
 
-            tapoStartManualAlarmButton = await check_and_create(
-                entry, hass, TapoStartManualAlarmButton, "getAlarm", config_entry
-            )
-            if tapoStartManualAlarmButton:
-                LOGGER.debug("Adding tapoStartManualAlarmButton...")
-                buttons.append(tapoStartManualAlarmButton)
+            if supports_manual_siren(entry.get("camData")):
+                tapoStartManualAlarmButton = await check_and_create(
+                    entry, hass, TapoStartManualAlarmButton, "getAlarm", config_entry
+                )
+                if tapoStartManualAlarmButton:
+                    LOGGER.debug("Adding tapoStartManualAlarmButton...")
+                    buttons.append(tapoStartManualAlarmButton)
 
-            tapoStopManualAlarmButton = await check_and_create(
-                entry, hass, TapoStopManualAlarmButton, "getAlarm", config_entry
-            )
-            if tapoStopManualAlarmButton:
-                LOGGER.debug("Adding tapoStopManualAlarmButton...")
-                buttons.append(tapoStopManualAlarmButton)
+                tapoStopManualAlarmButton = await check_and_create(
+                    entry, hass, TapoStopManualAlarmButton, "getAlarm", config_entry
+                )
+                if tapoStopManualAlarmButton:
+                    LOGGER.debug("Adding tapoStopManualAlarmButton...")
+                    buttons.append(tapoStopManualAlarmButton)
+            else:
+                LOGGER.debug(
+                    "Skipping Manual Alarm buttons: model does not support "
+                    "manual siren."
+                )
 
             if not entry["isParent"] and entry["controller"].isKLAP is False:
                 buttons.append(TapoSyncTimeButton(entry, hass, config_entry))

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -106,11 +106,3 @@ TAPO_PREFIXES = (
     r"^d[0-9]{3}[a-zA-Z]*c_.*",  # Doorbell Chimes (D100C, D230C, D325C, etc.)
     r"^h[0-9]{3}[a-zA-Z]*_.*",  # Smart Hubs (H100, H200, H300, etc.)
 )
-
-# Models with no way to trigger the siren on demand: startManualAlarm,
-# setSirenStatus and testUsrDefAudio all return -40106/-40210 and the Tapo
-# app offers no manual siren button for them (alarm only fires on motion
-# detection). Creating the Siren entity or the Manual Alarm Start/Stop
-# buttons for these models gives users controls that always fail.
-# See #373, #678 and discussion #978.
-MODELS_WITHOUT_MANUAL_SIREN = ("C320WS",)

--- a/custom_components/tapo_control/const.py
+++ b/custom_components/tapo_control/const.py
@@ -106,3 +106,11 @@ TAPO_PREFIXES = (
     r"^d[0-9]{3}[a-zA-Z]*c_.*",  # Doorbell Chimes (D100C, D230C, D325C, etc.)
     r"^h[0-9]{3}[a-zA-Z]*_.*",  # Smart Hubs (H100, H200, H300, etc.)
 )
+
+# Models with no way to trigger the siren on demand: startManualAlarm,
+# setSirenStatus and testUsrDefAudio all return -40106/-40210 and the Tapo
+# app offers no manual siren button for them (alarm only fires on motion
+# detection). Creating the Siren entity or the Manual Alarm Start/Stop
+# buttons for these models gives users controls that always fail.
+# See #373, #678 and discussion #978.
+MODELS_WITHOUT_MANUAL_SIREN = ("C320WS",)

--- a/custom_components/tapo_control/number.py
+++ b/custom_components/tapo_control/number.py
@@ -9,7 +9,7 @@ from homeassistant.const import STATE_UNAVAILABLE, UnitOfTime
 
 from .const import DOMAIN, LOGGER
 from .tapo.entities import TapoEntity, TapoNumberEntity
-from .utils import check_and_create, check_functionality
+from .utils import check_and_create, check_functionality, spotlight_intensity_uses_select, resolve_spotlight_intensity_max
 
 
 async def async_setup_entry(
@@ -107,14 +107,16 @@ async def async_setup_entry(
                 LOGGER.debug("Adding TapoSirenDuration...")
                 numbers.append(tapoSirenDuration)
 
-        if (
-            entry["camData"]["whitelampConfigIntensity"] is not None
-            and entry["camData"]["smartwtl_digital_level"] is not None
-        ):
+        if entry["camData"]["whitelampConfigIntensity"] is not None:
             if entry["chInfo"]:
                 for lens in entry["chInfo"]:
                     chn_alias = lens.get("chn_alias", "")
                     chn_id = lens.get("chn_id")
+                    read_chn_id = str(chn_id) if chn_id else "1"
+                    if spotlight_intensity_uses_select(
+                        entry["camData"], read_chn_id
+                    ):
+                        continue
                     tapoSpotlightIntensity = TapoSpotlightIntensity(
                         entry, hass, config_entry, chn_alias, chn_id
                     )
@@ -123,7 +125,7 @@ async def async_setup_entry(
                             f"Adding tapoSpotlightIntensity for {chn_alias}, id: {chn_id}..."
                         )
                         numbers.append(tapoSpotlightIntensity)
-            else:
+            elif not spotlight_intensity_uses_select(entry["camData"]):
                 tapoSpotlightIntensity = TapoSpotlightIntensity(
                     entry, hass, config_entry
                 )
@@ -716,60 +718,15 @@ class TapoSpotlightIntensity(TapoNumberEntity):
         self.chn_id = chn_id
         self.read_chn_id = str(chn_id) if chn_id else "1"
 
-        ldc_style = entry["camData"].get("ldcStyle")
-        if isinstance(ldc_style, dict):
-            ldc_style = entry["camData"].get("ldcStyle").get(self.read_chn_id)
-            if not ldc_style and chn_id > 1:
-                ldc_style = entry["camData"].get("ldcStyle").get("1")
-
-        smartwtl_level = entry["camData"].get("smartwtl_digital_level")
-        if isinstance(smartwtl_level, dict):
-            smartwtl_level = (
-                entry["camData"].get("smartwtl_digital_level").get(self.read_chn_id)
-            )
-            if not smartwtl_level and chn_id > 1:
-                smartwtl_level = entry["camData"].get("smartwtl_digital_level").get("1")
-
-        if ldc_style:
-            if ldc_style == "standard":
-                LOGGER.debug(
-                    "Determining maximum range for TapoSpotlightIntensity: standard"
-                )
-                self._attr_max_value = 5
-                self._attr_native_max_value = 5
-            else:
-                LOGGER.debug(
-                    "Determining maximum range for TapoSpotlightIntensity: "
-                    + str(ldc_style)
-                )
-                if smartwtl_level is not None:
-                    self._attr_max_value = int(smartwtl_level)
-                    self._attr_native_max_value = int(smartwtl_level)
-                else:
-                    self._attr_max_value = 100
-                    self._attr_native_max_value = 100
-        else:
-            LOGGER.debug(
-                "Determining maximum range for TapoSpotlightIntensity: Default to 100 because of missing style."
-            )
-            self._attr_max_value = 100
-            self._attr_native_max_value = 100
-
-        # Some C320WS firmwares report getLdc style as "original" together
-        # with a smartwtl_digital_level of 100, yet the camera rejects any
-        # intensity above 5 with -40101 (the Tapo app also only offers 1-5
-        # for this model). See #979.
-        device_model = (
-            entry.get("camData", {}).get("basic_info", {}).get("device_model") or ""
+        max_value = resolve_spotlight_intensity_max(
+            entry["camData"], self.read_chn_id
         )
-        if device_model.startswith("C320WS") and self._attr_max_value > 5:
-            LOGGER.debug(
-                "Capping TapoSpotlightIntensity max at 5 for %s (reported %s)",
-                device_model,
-                self._attr_max_value,
-            )
-            self._attr_max_value = 5
-            self._attr_native_max_value = 5
+        LOGGER.debug(
+            "Determining maximum range for TapoSpotlightIntensity: %s",
+            max_value,
+        )
+        self._attr_max_value = max_value
+        self._attr_native_max_value = max_value
 
         self._attr_step = 1
         self._hass = hass

--- a/custom_components/tapo_control/number.py
+++ b/custom_components/tapo_control/number.py
@@ -754,6 +754,23 @@ class TapoSpotlightIntensity(TapoNumberEntity):
             )
             self._attr_max_value = 100
             self._attr_native_max_value = 100
+
+        # Some C320WS firmwares report getLdc style as "original" together
+        # with a smartwtl_digital_level of 100, yet the camera rejects any
+        # intensity above 5 with -40101 (the Tapo app also only offers 1-5
+        # for this model). See #979.
+        device_model = (
+            entry.get("camData", {}).get("basic_info", {}).get("device_model") or ""
+        )
+        if device_model.startswith("C320WS") and self._attr_max_value > 5:
+            LOGGER.debug(
+                "Capping TapoSpotlightIntensity max at 5 for %s (reported %s)",
+                device_model,
+                self._attr_max_value,
+            )
+            self._attr_max_value = 5
+            self._attr_native_max_value = 5
+
         self._attr_step = 1
         self._hass = hass
         intensity = entry["camData"]["whitelampConfigIntensity"]

--- a/custom_components/tapo_control/select.py
+++ b/custom_components/tapo_control/select.py
@@ -12,6 +12,8 @@ from .utils import (
     check_functionality,
     getNightModeName,
     getNightModeValue,
+    spotlight_intensity_uses_select,
+    resolve_spotlight_intensity_max,
 )
 
 
@@ -347,10 +349,7 @@ async def async_setup_entry(
                         TapoWhitelampForceTimeSelect(entry, hass, config_entry)
                     )
 
-        if (
-            entry["camData"]["whitelampConfigIntensity"] is not None
-            and entry["camData"]["smartwtl_digital_level"] is None
-        ):
+        if entry["camData"]["whitelampConfigIntensity"] is not None:
             tapoWhitelampIntensityLevelSelectAvailable = await check_functionality(
                 entry, hass, TapoWhitelampIntensityLevelSelect, "getWhitelampConfig"
             )
@@ -359,6 +358,11 @@ async def async_setup_entry(
                     for lens in entry["chInfo"]:
                         chn_alias = lens.get("chn_alias", "")
                         chn_id = lens.get("chn_id")
+                        read_chn_id = str(chn_id) if chn_id else "1"
+                        if not spotlight_intensity_uses_select(
+                            entry["camData"], read_chn_id
+                        ):
+                            continue
                         LOGGER.debug(
                             f"Adding TapoWhitelampIntensityLevelSelect for {chn_alias}, id: {chn_id}..."
                         )
@@ -367,7 +371,7 @@ async def async_setup_entry(
                                 entry, hass, config_entry, chn_alias, chn_id
                             )
                         )
-                else:
+                elif spotlight_intensity_uses_select(entry["camData"]):
                     LOGGER.debug("Adding TapoWhitelampIntensityLevelSelect...")
                     selects.append(
                         TapoWhitelampIntensityLevelSelect(entry, hass, config_entry)
@@ -588,10 +592,13 @@ class TapoWhitelampIntensityLevelSelect(TapoSelectEntity):
         specific_name=None,
         chn_id=None,
     ):
-        self._attr_options = ["1", "2", "3", "4", "5"]
-        self._attr_current_option = None
         self.chn_id = chn_id
         self.read_chn_id = str(chn_id) if chn_id else "1"
+        max_level = resolve_spotlight_intensity_max(
+            entry["camData"], self.read_chn_id
+        )
+        self._attr_options = [str(i) for i in range(1, max_level + 1)]
+        self._attr_current_option = None
         TapoSelectEntity.__init__(
             self,
             f"Spotlight Intensity{" - " + specific_name if specific_name else ""}",

--- a/custom_components/tapo_control/siren.py
+++ b/custom_components/tapo_control/siren.py
@@ -21,9 +21,9 @@ async def async_setup_entry(
 
     async def setupEntities(entry):
         sirens = []
-        if not supports_manual_siren(entry.get("camData")):
+        if not await supports_manual_siren(hass, entry):
             LOGGER.debug(
-                "Skipping Siren entity: model does not support manual siren."
+                "Skipping Siren entity: on-demand manual siren unavailable."
             )
             return sirens
         tapoSiren = await check_and_create(

--- a/custom_components/tapo_control/siren.py
+++ b/custom_components/tapo_control/siren.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, LOGGER
 from .tapo.entities import TapoEntity
-from .utils import check_and_create, result_has_error
+from .utils import check_and_create, result_has_error, supports_manual_siren
 
 
 async def async_setup_entry(
@@ -21,6 +21,11 @@ async def async_setup_entry(
 
     async def setupEntities(entry):
         sirens = []
+        if not supports_manual_siren(entry.get("camData")):
+            LOGGER.debug(
+                "Skipping Siren entity: model does not support manual siren."
+            )
+            return sirens
         tapoSiren = await check_and_create(
             entry, hass, TapoSiren, "getAlarm", config_entry
         )

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -59,6 +59,7 @@ from .const import (
     CONF_CUSTOM_STREAM_7,
     MEDIA_SYNC_COLD_STORAGE_PATH,
     MEDIA_SYNC_HOURS,
+    MODELS_WITHOUT_MANUAL_SIREN,
     TIME_SYNC_DST,
     TIME_SYNC_NDST,
     TPLINK_DOMAIN,
@@ -806,6 +807,18 @@ def result_has_error(result):
         return False
     else:
         return True
+
+
+def supports_manual_siren(camData):
+    """Whether the camera can trigger its siren on demand. Known-unsupported
+    models are listed in MODELS_WITHOUT_MANUAL_SIREN; for those we skip
+    creating the Siren entity and the Manual Alarm Start/Stop buttons."""
+    if not camData:
+        return True
+    device_model = (camData.get("basic_info") or {}).get("device_model") or ""
+    return not any(
+        device_model.startswith(prefix) for prefix in MODELS_WITHOUT_MANUAL_SIREN
+    )
 
 
 async def initOnvifEvents(hass, host, username, password):

--- a/custom_components/tapo_control/utils.py
+++ b/custom_components/tapo_control/utils.py
@@ -59,7 +59,6 @@ from .const import (
     CONF_CUSTOM_STREAM_7,
     MEDIA_SYNC_COLD_STORAGE_PATH,
     MEDIA_SYNC_HOURS,
-    MODELS_WITHOUT_MANUAL_SIREN,
     TIME_SYNC_DST,
     TIME_SYNC_NDST,
     TPLINK_DOMAIN,
@@ -809,16 +808,118 @@ def result_has_error(result):
         return True
 
 
-def supports_manual_siren(camData):
-    """Whether the camera can trigger its siren on demand. Known-unsupported
-    models are listed in MODELS_WITHOUT_MANUAL_SIREN; for those we skip
-    creating the Siren entity and the Manual Alarm Start/Stop buttons."""
-    if not camData:
-        return True
-    device_model = (camData.get("basic_info") or {}).get("device_model") or ""
-    return not any(
-        device_model.startswith(prefix) for prefix in MODELS_WITHOUT_MANUAL_SIREN
+def _spotlight_channel_value(camData, field, read_chn_id="1"):
+    """Return a per-channel LDC/spotlight field from camData."""
+    val = camData.get(field)
+    if isinstance(val, dict):
+        return val.get(read_chn_id) or val.get("1")
+    return val
+
+
+def resolve_spotlight_intensity_max(camData, read_chn_id="1"):
+    """Maximum spotlight intensity the camera accepts.
+
+    The Tapo app uses smartwtl_level (discrete step count, often 5) rather than
+    smartwtl_digital_level (internal scale, often 100). See #637 and #979.
+    """
+    ldc_style = _spotlight_channel_value(camData, "ldcStyle", read_chn_id)
+    smartwtl_level = _spotlight_channel_value(camData, "smartwtl_level", read_chn_id)
+    smartwtl_digital_level = _spotlight_channel_value(
+        camData, "smartwtl_digital_level", read_chn_id
     )
+
+    if ldc_style == "standard":
+        return 5
+    if smartwtl_level is not None:
+        return int(smartwtl_level)
+    if smartwtl_digital_level is not None:
+        return int(smartwtl_digital_level)
+    return 100
+
+
+def spotlight_intensity_uses_select(camData, read_chn_id="1"):
+    """Whether spotlight intensity should be a select (1-N) vs a number slider.
+
+    When both smartwtl_level and smartwtl_digital_level are present, cameras
+    that expose a small discrete level count use the select UI in the Tapo app.
+    """
+    if _spotlight_channel_value(camData, "smartwtl_digital_level", read_chn_id) is None:
+        return True
+    smartwtl_level = _spotlight_channel_value(camData, "smartwtl_level", read_chn_id)
+    if smartwtl_level is not None:
+        return int(smartwtl_level) <= 5
+    return False
+
+
+_MANUAL_SIREN_UNSUPPORTED = ("-40106", "-40210", "UNSUPPORTED_METHOD", "METHOD_DO_NOT_EXIST")
+
+
+def _manual_siren_probe_failed(exc):
+    msg = str(exc)
+    return any(code in msg for code in _MANUAL_SIREN_UNSUPPORTED)
+
+
+def probe_manual_siren_supported(controller):
+    """Probe whether on-demand siren control is available without sounding it."""
+    probes = (
+        ("stopManualAlarm", lambda: controller.stopManualAlarm()),
+        ("setSirenStatus(off)", lambda: controller.setSirenStatus(False)),
+        ("testUsrDefAudio(stop)", lambda: controller.testUsrDefAudio(0, False)),
+    )
+    had_unexpected = False
+    for name, probe in probes:
+        try:
+            probe()
+            LOGGER.debug("Manual siren probe succeeded via %s", name)
+            return True
+        except Exception as err:
+            if _manual_siren_probe_failed(err):
+                LOGGER.debug("Manual siren probe %s unsupported: %s", name, err)
+                continue
+            had_unexpected = True
+            LOGGER.warning(
+                "Manual siren probe %s unexpected error: %s", name, err
+            )
+    if had_unexpected:
+        LOGGER.debug(
+            "Manual siren probe inconclusive; keeping manual siren entities"
+        )
+        return True
+    return False
+
+
+async def supports_manual_siren(hass, entry):
+    """Whether the camera supports on-demand manual siren control.
+
+    Hub sirens are always supported. For cameras, a silent runtime probe is
+    used because getAlarmConfig alone does not indicate manual trigger support.
+    """
+    if "manualSirenSupported" in entry:
+        return entry["manualSirenSupported"]
+
+    camData = entry.get("camData") or {}
+    if camData.get("alarm_is_hubSiren"):
+        entry["manualSirenSupported"] = True
+        return True
+
+    controller = entry.get("controller")
+    if not controller:
+        entry["manualSirenSupported"] = False
+        return False
+    if controller.isKLAP:
+        # KLAP devices use a different alarm API; keep existing entity creation.
+        entry["manualSirenSupported"] = True
+        return True
+
+    supported = await hass.async_add_executor_job(
+        probe_manual_siren_supported, controller
+    )
+    entry["manualSirenSupported"] = supported
+    if not supported:
+        LOGGER.debug(
+            "Skipping manual siren entities: on-demand siren control unavailable"
+        )
+    return supported
 
 
 async def initOnvifEvents(hass, host, username, password):
@@ -1418,6 +1519,12 @@ async def getCamData(hass, controller, chInfo=None):
     except Exception:
         smartwtl_digital_level = None
     camData["smartwtl_digital_level"] = smartwtl_digital_level
+
+    try:
+        smartwtl_level = extractFieldByChannel(ldc_common, "smartwtl_level")
+    except Exception:
+        smartwtl_level = None
+    camData["smartwtl_level"] = smartwtl_level
 
     try:
         flood_light_config = data["getFloodlightConfig"][0]["floodlight"]["config"]


### PR DESCRIPTION
## Summary
Two small, C320WS-focused fixes that avoid broken controls and invalid slider ranges. Both are backed by existing upstream reports (#979, #373, #678, discussion #978).
- **Spotlight intensity:** Some C320WS firmwares report `smartwtl_digital_level` as 100 (or similar) while the camera rejects any value above 5 with `-40101`. The Tapo app only exposes 1–5 for this model. Cap `TapoSpotlightIntensity` max at 5 when `device_model` starts with `C320WS`.
- **Manual siren / alarm buttons:** C320WS has no API to trigger the siren on demand (`startManualAlarm`, `setSirenStatus`, and `testUsrDefAudio` return `-40106`/`-40210`; the Tapo app has no manual siren button). Add `MODELS_WITHOUT_MANUAL_SIREN` and skip creating the Siren entity and Manual Alarm Start/Stop buttons for matching models so users do not see controls that always fail.
## Test plan
- [x] C320WS: Spotlight Intensity number entity shows max 5; values 1–5 apply without `-40101` errors
- [x] C320WS: Siren toggle and Manual Alarm Start/Stop buttons are not created after reload
## Missing tests (I just have C320WS cameras)
- [ ] C210/C520WS (or any camera with working manual siren): Siren entity and alarm buttons still appear and work
- [ ] Non-C320WS camera with digital spotlight intensity: slider range unchanged