### PR TITLE
Use device registry helper when removing devices after IP change

### DIFF
--- a/custom_components/tapo_control/config_flow.py
+++ b/custom_components/tapo_control/config_flow.py
@@ -12,7 +12,10 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_EMAIL,
 )
-from homeassistant.helpers.device_registry import async_get as device_registry_async_get
+from homeassistant.helpers.device_registry import (
+    async_entries_for_config_entry as device_registry_async_entries_for_config_entry,
+    async_get as device_registry_async_get,
+)
 from homeassistant.helpers.selector import selector
 
 from .utils import (
@@ -1832,15 +1835,12 @@ class TapoOptionsFlowHandler(OptionsFlow):
                     camData = await getCamData(self.hass, tapoController)
                     reported_ip_address = getIP(camData)
                     device_registry = device_registry_async_get(self.hass)
-                    devices_to_remove = []
-                    for deviceID in device_registry.devices:
-                        device = device_registry.devices[deviceID]
-                        if (
-                            len(device.config_entries)
-                            and list(device.config_entries)[0]
-                            == self.config_entry.entry_id
-                        ):
-                            devices_to_remove.append(device.id)
+                    devices_to_remove = [
+                        device.id
+                        for device in device_registry_async_entries_for_config_entry(
+                            device_registry, self.config_entry.entry_id
+                        )
+                    ]
                     for deviceID in devices_to_remove:
                         LOGGER.debug("[%s] Removing device %s.", ip_address, deviceID)
                         device_registry.async_remove_device(deviceID)


### PR DESCRIPTION
## Summary

Fixes #1418. Home Assistant 2026.9.0 changed `DeviceRegistry.devices` from a device id keyed mapping to a collection of `DeviceEntry` objects. The options flow iterated it as a mapping, so on the IP-address-changed path the loop yielded `DeviceEntry` objects and the subscript raised `KeyError`. Replaced with the public `async_entries_for_config_entry` helper.

This also drops the use of `DeviceEntry.config_entries`, which is itself a deprecated compatibility shim in 2026.9.0.

On the old-vs-new selection: in 2026.9.0 `config_entries` returns a single element set `{config_entry_id}`, so the old "first config entry is ours" check and "belongs to this config entry" pick the same devices. On older cores `config_entries` is an unordered set, so `list(...)[0]` was already non-deterministic for any multi-entry device; this integration creates one device per camera per entry, so I do not expect a difference.

## Scope

- [x] This PR is small and focused on one issue or one tightly related behavior.
- [x] I read the relevant README, FAQ, issues, and surrounding code before changing behavior.
- [x] I preserved existing behavior unless this PR explicitly explains and justifies the behavior change.
- [x] I updated documentation and translations, or this PR has no user-facing behavior/message changes.

## Testing

Commands run:

```text
python3 -m compileall -q custom_components/tapo_control
black --check custom_components/tapo_control/config_flow.py
flake8 custom_components/tapo_control/config_flow.py   (no new findings vs main)
pytest on two standalone verification scripts, described below
```

Manual verification:

```text
Home Assistant 2026.9.0 requires Python 3.14, which was not available in the environment used for verification, so the check was made against the 2026.9.0 source instead:

1. Copied the _DeprecatedDeviceRegistryItemsView class verbatim from the core 2026.9.0 tag and ran the loop this PR removes against it. It raises KeyError, which is the bug reported in #1418.
2. On a real Home Assistant device registry (2026.2.3, via pytest-homeassistant-custom-component), created two config entries with three devices between them and confirmed the removed loop and async_entries_for_config_entry select the same device ids.
3. Confirmed async_entries_for_config_entry exists in device_registry.py at core tags 2025.10.0 (the hacs.json minimum) and 2026.9.0, and that DeviceEntry.config_entries at 2026.9.0 returns {self.config_entry_id}.

The verification scripts are not in this PR; the repository has no test suite and I did not want to add one as a side effect of a small fix. Happy to include them if you would like them.
```

Home Assistant testing with AI assistant, if any:

```text
None. I do not own a Tapo camera, so the options flow was not run in a live Home Assistant. My own instance is on 2026.9.0 but has no camera to attach.
```

Tested device models, firmware, and Home Assistant version:

```text
No camera involved. Verification was against the 2026.9.0 device registry source and a real registry on 2026.2.3 via pytest-homeassistant-custom-component.
```

Not tested:

```text
- Not run on a live Home Assistant 2026.9.0.
- The options flow was not exercised end to end. The changed lines are only reached after registerController and getCamData succeed against a real camera.
```

## AI Assistance Disclosure

- [ ] No AI tools were used for this PR.
- [x] AI tools assisted with this PR, and I reviewed and understand all generated changes.

```text
AI assistance: yes
Tool(s): Claude Code (Claude Opus 5)
AI contribution level: small snippets
AI contribution: Drafted the config_flow.py change (the import and the list comprehension), the two verification scripts run outside the repository, and a first draft of this description.
Human review: I read the diff, checked async_entries_for_config_entry and the config_entries shim against the core 2025.10.0 and 2026.9.0 sources, and reviewed this description.
Home Assistant testing with user: none, no camera available.
```
